### PR TITLE
feat: Support DFR TYXAL+

### DIFF
--- a/src/accessories/smokeDetector.ts
+++ b/src/accessories/smokeDetector.ts
@@ -1,0 +1,87 @@
+import type {PlatformAccessory} from 'homebridge';
+import {Characteristic, CharacteristicEventTypes, CharacteristicValue, NodeCallback, Service} from '../config/hap';
+import TydomController from '../controller';
+import {
+  addAccessoryService,
+  getAccessoryService,
+  setupAccessoryIdentifyHandler,
+  setupAccessoryInformationService
+} from '../helpers/accessory';
+import {getTydomDataPropValue, getTydomDeviceData} from '../helpers/tydom';
+import type {TydomAccessoryContext, TydomDeviceSmokeDetectorData} from '../typings/tydom';
+import {debugGet, debugGetResult, debugSetUpdate} from '../utils/debug';
+import {Formats} from 'homebridge';
+
+export const setupSmokeDetector = (
+  accessory: PlatformAccessory<TydomAccessoryContext>,
+  controller: TydomController
+): void => {
+  const {context} = accessory;
+  const {client} = controller;
+  const {SmokeDetected, StatusLowBattery} = Characteristic;
+
+  const {deviceId, endpointId} = context;
+  setupAccessoryInformationService(accessory, controller);
+  setupAccessoryIdentifyHandler(accessory, controller);
+
+  // Add the actual accessory Service
+  const service = addAccessoryService(accessory, Service.SmokeSensor, `${accessory.displayName}`, true);
+
+  service
+    .getCharacteristic(SmokeDetected)
+    .setProps({
+      format: Formats.BOOL
+    })
+    .on(CharacteristicEventTypes.GET, async (callback: NodeCallback<CharacteristicValue>) => {
+      debugGet(SmokeDetected, service);
+      try {
+        const data = await getTydomDeviceData<TydomDeviceSmokeDetectorData>(client, {deviceId, endpointId});
+        const smokeDefect = getTydomDataPropValue<boolean>(data, 'techSmokeDefect');
+        debugGetResult(SmokeDetected, service, smokeDefect);
+        callback(null, smokeDefect);
+      } catch (err) {
+        callback(err as Error);
+      }
+    });
+
+  service
+    .getCharacteristic(StatusLowBattery)
+    .on(CharacteristicEventTypes.GET, async (callback: NodeCallback<CharacteristicValue>) => {
+      debugGet(StatusLowBattery, service);
+      try {
+        const data = await getTydomDeviceData<TydomDeviceSmokeDetectorData>(client, {deviceId, endpointId});
+        const battDefect = getTydomDataPropValue<boolean>(data, 'battDefect');
+        debugGetResult(StatusLowBattery, service, battDefect);
+        callback(null, battDefect ? StatusLowBattery.BATTERY_LEVEL_LOW : StatusLowBattery.BATTERY_LEVEL_NORMAL);
+      } catch (err) {
+        callback(err as Error);
+      }
+    });
+};
+
+export const updateSmokeDetector = (
+  accessory: PlatformAccessory<TydomAccessoryContext>,
+  _controller: TydomController,
+  updates: Record<string, unknown>[]
+): void => {
+  updates.forEach((update) => {
+    const {name, value} = update;
+    const {SmokeDetected, StatusLowBattery} = Characteristic;
+    switch (name) {
+      case 'techSmokeDefect': {
+        const service = getAccessoryService(accessory, Service.SmokeSensor);
+        debugSetUpdate(SmokeDetected, service, value);
+        service.updateCharacteristic(SmokeDetected, value as boolean);
+        return;
+      }
+      case 'battDefect': {
+        const service = getAccessoryService(accessory, Service.SmokeSensor);
+        debugSetUpdate(StatusLowBattery, service, value);
+        service.updateCharacteristic(StatusLowBattery, value as number);
+        return;
+      }
+      default:
+        return;
+    }
+  });
+};

--- a/src/helpers/accessory.ts
+++ b/src/helpers/accessory.ts
@@ -15,6 +15,7 @@ import {AccessoryEventTypes, Categories, Characteristic, Service as ServiceStati
 import TydomController from '../controller';
 import {TydomAccessoryContext} from '../typings/tydom';
 import {assert, debug} from '../utils';
+import {setupSmokeDetector, updateSmokeDetector} from 'src/accessories/smokeDetector';
 
 export const SECURITY_SYSTEM_SENSORS = parseInt(`${Categories.SECURITY_SYSTEM}0`);
 
@@ -97,7 +98,7 @@ export const getTydomAccessorySetup = <T extends TydomAccessoryContext<any, any>
     case Categories.SECURITY_SYSTEM:
       return setupSecuritySystem;
     case Categories.SENSOR:
-      return setupTemperatureSensor;
+      return context.settings?.smokeDetector ? setupSmokeDetector : setupTemperatureSensor;
     case Categories.WINDOW:
     case Categories.DOOR:
       return setupContactSensor;
@@ -140,7 +141,7 @@ export const getTydomAccessoryDataUpdate = <T extends TydomAccessoryContext<any,
     case Categories.SECURITY_SYSTEM:
       return updateSecuritySystem;
     case Categories.SENSOR:
-      return updateTemperatureSensor;
+      return context.settings?.smokeDetector ? updateSmokeDetector : updateTemperatureSensor;
     case Categories.WINDOW:
     case Categories.DOOR:
       return updateContactSensor;

--- a/src/helpers/tydom.ts
+++ b/src/helpers/tydom.ts
@@ -154,7 +154,8 @@ const ENDPOINTS_SIGNATURES_CATEGORIES: Record<string, Categories | [Categories, 
   'others:449e2a60377094cde10224cee91d378fb0ae373ae6ceea0ac2cbc1ed011bffa7': Categories.LIGHTBULB, // @diegomarino (TYXIA 4600)
   'plug:2534c497ff8fb013a88da28d341adff5bc0ba77e1fc8ea8dcb8b8f1c9d62ce19': Categories.OUTLET, // @Neo33ASM (Easy Plug)
   'shutter:c3fe8e2afa864e1a7a5c6676b4287a7b2f2a886a466baec3df8a1ec4f898ad6c': Categories.WINDOW_COVERING, // @maaxleop
-  'window:fb935867933d89b3058f09384f76fd63f3defb18cfb3172f60fa9f4f237f748b': Categories.WINDOW // @mgcrea (MDO)
+  'window:fb935867933d89b3058f09384f76fd63f3defb18cfb3172f60fa9f4f237f748b': Categories.WINDOW, // @mgcrea (MDO)
+  'sensor:556f8aaf51e3807397b7e326d0aad4b61cceb8279166b50204f8a2e95464c9ba': [Categories.SENSOR, {smokeDetector: true}] // DFR TYXAL+
 };
 
 type ResolveEndpointCategoryOptions = {

--- a/src/typings/tydom.ts
+++ b/src/typings/tydom.ts
@@ -155,6 +155,11 @@ export type TydomDeviceSecuritySystemData = [
   TydomDataElement<'irv4State', 'AVAILABLE' | 'UNAVAILABLE' | 'LOCKED'>
 ];
 
+export type TydomDeviceSmokeDetectorData = [
+  TydomDataElement<'techSmokeDefect', boolean>,
+  TydomDataElement<'battDefect', boolean>
+];
+
 export type TydomDeviceDataUpdateBody = {
   id: number;
   endpoints: {id: number; error: number; data: Record<string, unknown>[]; cdata: Record<string, unknown>[]}[];


### PR DESCRIPTION
Salut,

Je suis en train de faire construire et le constructeur m'a livré une box Tydom Home. En voulant commencer à jouer un peu avec je me suis aperçu que le détecteur de fumée qu'il m'a fourni ne semble pas pris en charge par le plugin. J'avais ce message au lancement :

> [5/11/2023, 10:03:27 PM] [Tydom] Found new device with firstUsage='sensor', deviceId=1683699242 and endpointId=1683699242
  homebridge-tydom Unknown hash=sensor:556f8aaf51e3807397b7e326d0aad4b61cceb8279166b50204f8a2e95464c9ba with firstUsage="sensor" +1ms
[5/11/2023, 10:03:27 PM] [Tydom] Unsupported firstUsage="sensor" for endpoint with deviceId="1683699242"
  homebridge-tydom {
  homebridge-tydom   endpoint: {
  homebridge-tydom     first_usage: 'sensor',
  homebridge-tydom     picto: 'picto_sensor1',
  homebridge-tydom     id_endpoint: 1683699242,
  homebridge-tydom     last_usage: 'sensorDFR',
  homebridge-tydom     name: 'DFR 1',
  homebridge-tydom     anticipation_start: false,
  homebridge-tydom     id_device: 1683699242
  homebridge-tydom   }
  homebridge-tydom } +0ms
[5/11/2023, 10:03:27 PM] [Tydom] Properly loaded 0-accessories

N'ayant jamais développé de plugin Homebridge je me suis dis que c'était le moment d'essayer. Je me suis très largement inspiré du code pour le `temperatureSensor`, il y a sûrement des choses à revoir mais si ça peut servir de base pour ajouter la prise en charge...