### PR TITLE
feat(garageDoorOpener): initial attempt to support Novoferm ES423 with command ON/OFF instead of TOGGLE

### DIFF
--- a/src/typings/tydom.ts
+++ b/src/typings/tydom.ts
@@ -105,6 +105,8 @@ export type TydomDeviceThermostatData = [
   TydomDataElement<'boostOn', boolean>
 ];
 
+export type TydomDeviceGarageDoorData = [TydomDataElement<'level', number>];
+
 export type TydomDeviceShutterData = [
   TydomDataElement<'battDefect', boolean>,
   TydomDataElement<'intrusion', boolean>,


### PR DESCRIPTION
Salut @mgcrea,

Suite à cette issue https://github.com/mgcrea/homebridge-tydom/issues/143, j'ai commencé à regarder un peu comment je pouvais modifier le GarageDoorOpener pour supporter mes portes de garage Novoferm ES423 (qui ne comprennent pas l'instruction TOGGLE, mais réagissent aux commandes ON/OFF).

J'ai fait un build custom et tester dans Homebridge, cela fonctionne plutôt pas mal. 

Je n'ai pas trop d'idée sur comment intégrer ça autrement, garder le support TOGGLE pour ceux chez qui ça fonctionne et ajouter le ON/OFF pour les autres (comme moi).

PR créé pour ouvrir la discussion :) 

Ce qui fonctionne chez moi:

- Les portes sont reconnues dans Apple Home
- Les portes peuvent s'ouvrir et se fermer depuis Apple Home
- Si quelqu'un utilise la télécommande Novoferm (fournie avec les moteurs de porte) pour ouvrir/fermer une porte, l'état remonte bien dans Apple Home (si cette fermeture n'est pas faite pendant une action en cours côté Apple Home).
- L'état ouvert/fermé est récupéré à l'initialisation de l'accessoire.