### PR TITLE
feat: fix autoclose bug in Home and add support of virtual close (or not)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,14 +159,17 @@ Value is in milliseconds:
 }
 ```
 
-You can also configure an `autoCloseDelay`
+You can also configure an `autoCloseDelay` and `autoCloseVirtual` to physically or virtually close the garage door.
 
 ```json
 {
   "platforms": [
     {
       "settings": {
-        "1529094720": {"autoCloseDelay": 300000} // 5 minutes
+        "1529094720": {
+          "autoCloseDelay": 300000, // 5 minutes
+          "autoCloseVirtual": true
+        }
       }
     }
   ]

--- a/src/accessories/garageDoorOpener.ts
+++ b/src/accessories/garageDoorOpener.ts
@@ -31,6 +31,7 @@ import {Characteristic, Service} from 'src/config/hap';
 type GarageDoorOpenerSettings = {
   delay?: number;
   autoCloseDelay?: number;
+  virtual?: boolean;
 };
 type GarageDoorOpenerState = {
   currentDoorState: number;
@@ -52,7 +53,7 @@ export const setupGarageDoorOpener = (
 
   const {deviceId, endpointId, state, settings} = context;
 
-  const {delay: garageDoorDelay = DEFAULT_GARAGE_DOOR_DELAY, autoCloseDelay} = settings;
+  const {delay: garageDoorDelay = DEFAULT_GARAGE_DOOR_DELAY, autoCloseDelay, virtual = true} = settings;
 
   const assignState = (update: Partial<GarageDoorOpenerState>): void => {
     Object.assign(state, update);
@@ -208,7 +209,7 @@ export const setupGarageDoorOpener = (
           callback();
           return;
         }
-        if (targetDoorState == TargetDoorState.OPEN) {
+        if (targetDoorState == TargetDoorState.OPEN || (targetDoorState == TargetDoorState.CLOSED && !virtual)) {
           await toggleGarageDoor();
         }
         assignCurrentDoorState(nextCurrentDoorState);
@@ -252,7 +253,7 @@ export const setupGarageDoorOpener = (
             const delay = (state.computedPosition * garageDoorDelay) / 100;
             // debug(`delay=${chalkNumber(delay)}`);
             try {
-              await waitFor(`${deviceId}.pending`, autoCloseDelay ? 1 * 1000 : delay);
+              await waitFor(`${deviceId}.pending`, autoCloseDelay && virtual ? 1 * 1000 : delay);
               assignCurrentDoorState(CurrentDoorState.CLOSED);
             } catch (err) {
               // debug(`Aborted CLOSED update with delay=${chalkNumber(delay)}`);

--- a/src/accessories/garageDoorOpener.ts
+++ b/src/accessories/garageDoorOpener.ts
@@ -31,7 +31,7 @@ import {Characteristic, Service} from 'src/config/hap';
 type GarageDoorOpenerSettings = {
   delay?: number;
   autoCloseDelay?: number;
-  virtual?: boolean;
+  autoCloseVirtual?: boolean;
 };
 type GarageDoorOpenerState = {
   currentDoorState: number;
@@ -53,7 +53,7 @@ export const setupGarageDoorOpener = (
 
   const {deviceId, endpointId, state, settings} = context;
 
-  const {delay: garageDoorDelay = DEFAULT_GARAGE_DOOR_DELAY, autoCloseDelay, virtual = true} = settings;
+  const {delay: garageDoorDelay = DEFAULT_GARAGE_DOOR_DELAY, autoCloseDelay, autoCloseVirtual} = settings;
 
   const assignState = (update: Partial<GarageDoorOpenerState>): void => {
     Object.assign(state, update);
@@ -209,7 +209,7 @@ export const setupGarageDoorOpener = (
           callback();
           return;
         }
-        if (targetDoorState == TargetDoorState.OPEN || (targetDoorState == TargetDoorState.CLOSED && !virtual)) {
+        if (targetDoorState == TargetDoorState.OPEN || (targetDoorState == TargetDoorState.CLOSED && !autoCloseVirtual)) {
           await toggleGarageDoor();
         }
         assignCurrentDoorState(nextCurrentDoorState);
@@ -250,10 +250,10 @@ export const setupGarageDoorOpener = (
             break;
           }
           case CurrentDoorState.CLOSING: {
-            const delay = (state.computedPosition * garageDoorDelay) / 100;
+            const delay = autoCloseDelay && autoCloseVirtual ? 1 * 1000 : (state.computedPosition * garageDoorDelay) / 100;
             // debug(`delay=${chalkNumber(delay)}`);
             try {
-              await waitFor(`${deviceId}.pending`, autoCloseDelay && virtual ? 1 * 1000 : delay);
+              await waitFor(`${deviceId}.pending`, delay);
               assignCurrentDoorState(CurrentDoorState.CLOSED);
             } catch (err) {
               // debug(`Aborted CLOSED update with delay=${chalkNumber(delay)}`);

--- a/src/accessories/garageDoorOpener.ts
+++ b/src/accessories/garageDoorOpener.ts
@@ -238,7 +238,8 @@ export const setupGarageDoorOpener = (
               assignCurrentDoorState(CurrentDoorState.OPEN);
               if (autoCloseDelay) {
                 await waitFor(`${deviceId}.pending`, autoCloseDelay);
-                assignCurrentDoorState(CurrentDoorState.CLOSED);
+                const targetDoorState = service.getCharacteristic(Characteristic.TargetDoorState);
+                targetDoorState.setValue(Characteristic.TargetDoorState.CLOSED);
               }
             } catch (err) {
               // debug(`Aborted OPEN update with delay=${chalkNumber(delay)}`);

--- a/src/accessories/garageDoorOpener.ts
+++ b/src/accessories/garageDoorOpener.ts
@@ -250,7 +250,7 @@ export const setupGarageDoorOpener = (
             const delay = (state.computedPosition * garageDoorDelay) / 100;
             // debug(`delay=${chalkNumber(delay)}`);
             try {
-              await waitFor(`${deviceId}.pending`, delay);
+              await waitFor(`${deviceId}.pending`, autoCloseDelay ? 1 * 1000 : delay);
               assignCurrentDoorState(CurrentDoorState.CLOSED);
             } catch (err) {
               // debug(`Aborted CLOSED update with delay=${chalkNumber(delay)}`);

--- a/src/accessories/garageDoorOpener.ts
+++ b/src/accessories/garageDoorOpener.ts
@@ -208,7 +208,9 @@ export const setupGarageDoorOpener = (
           callback();
           return;
         }
-        await toggleGarageDoor();
+        if (targetDoorState == TargetDoorState.OPEN) {
+          await toggleGarageDoor();
+        }
         assignCurrentDoorState(nextCurrentDoorState);
 
         // Handle Stopped state, if we are stopped, wait one second and trigger again to reverse course


### PR DESCRIPTION
### Description:
This PR addresses a bug where HomeKit hangs during the auto-close delay sequence described [here](https://github.com/mgcrea/homebridge-tydom/issues/152)

 ### Changelog:
- Fixed the issue where HomeKit would hang by ensuring the callback is called after handling the autoCloseDelay logic.
- Added autoCloseVirtual parameter to determine whether to physically toggle the door or handle it virtually during the auto-close delay.

### Tests:
on my local setup using `npm link`

fix https://github.com/mgcrea/homebridge-tydom/issues/152