### PR TITLE
Add local Tydom fallback recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@
     {
       "platform": "Tydom",
       "hostname": "mediation.tydom.com",
+      "localHostname": "192.168.0.X",
       "username": "001A25123456",
       "password": "YourPassw0rd",
       "debug": true
@@ -104,7 +105,7 @@ As HomeKit security system has 3 active levels: `stay`, `night`, `away` you can 
   "platforms": [
     {
       "settings": {
-        "1521931577": {"aliases": {"stay": [3], "night": [2, 3]}}
+        "1521931577": { "aliases": { "stay": [3], "night": [2, 3] } }
       }
     }
   ]
@@ -120,7 +121,7 @@ You can either add a `pin` field:
   "platforms": [
     {
       "settings": {
-        "1521931577": {"pin": "123456", "aliases": {"stay": [3], "night": [2, 3]}}
+        "1521931577": { "pin": "123456", "aliases": { "stay": [3], "night": [2, 3] } }
       }
     }
   ]
@@ -136,7 +137,7 @@ You can optionnaly rename zones (default is `Zone 1`, `Zone 2`, etc.),
   "platforms": [
     {
       "settings": {
-        "1521931577": {"zones": ["1st Floor", "Ground Floor", "Garden"]}
+        "1521931577": { "zones": ["1st Floor", "Ground Floor", "Garden"] }
       }
     }
   ]
@@ -154,7 +155,7 @@ Value is in milliseconds:
   "platforms": [
     {
       "settings": {
-        "1529094720": {"delay": 10000} // 10 seconds
+        "1529094720": { "delay": 10000 } // 10 seconds
       }
     }
   ]
@@ -168,7 +169,7 @@ You can also configure an `autoCloseDelay`
   "platforms": [
     {
       "settings": {
-        "1529094720": {"autoCloseDelay": 300000} // 5 minutes
+        "1529094720": { "autoCloseDelay": 300000 } // 5 minutes
       }
     }
   ]
@@ -208,7 +209,7 @@ You can override categories of devices (eg. some light switch used to manage a f
   "platforms": [
     {
       "settings": {
-        "1528565701": {"category": 3}
+        "1528565701": { "category": 3 }
       }
     }
   ]
@@ -239,25 +240,139 @@ Some other hardware that should work thanks to the community feedback:
 
 It is relatively easy to add new hardware so don't hesitate to create a new issue.
 
-### Notes
+### Local mode and fallback
 
-You can also use your local tydom IP (eg `192.168.0.X`) for `hostname`, however:
+By default, the plugin connects to the Delta Dore remote mediation server using `hostname`, usually `mediation.tydom.com`. You can enable a local fallback by keeping `hostname` on the remote server and adding `localHostname` with the local IP or hostname of your Tydom bridge.
 
-- You must set environment var `NODE_TLS_REJECT_UNAUTHORIZED=0` to interact with the self-signed certificate.
-- Tydom 2.0 firmware can sometimes have trouble dealing multiple local clients, locking you away from the mobile app.
+With this setup, the plugin first tries the primary `hostname`. If the remote server is unavailable at startup or during normal use, it switches to `localHostname` and keeps HomeKit working through your local network. While the local fallback is active, the plugin does not try both hosts for every request; instead, it retries the primary hostname every `primaryRetryInterval` seconds and switches back to the remote connection as soon as it is available again.
+
+Example configuration:
+
+```json
+{
+  "platform": "Tydom",
+  "hostname": "mediation.tydom.com",
+  "localHostname": "192.168.0.X",
+  "primaryRetryInterval": 300,
+  "username": "001A25XXXXXX",
+  "password": "YourPassw0rd",
+  "debug": true
+}
+```
+
+Relevant fields:
+
+| **Field**              | **Description**                                                                                 |
+| ---------------------- | ----------------------------------------------------------------------------------------------- |
+| `hostname`             | Primary Tydom endpoint. Use `mediation.tydom.com` for the regular remote Delta Dore connection. |
+| `localHostname`        | Optional local Tydom IP or hostname used when the primary endpoint is unavailable.              |
+| `primaryRetryInterval` | Optional retry interval, in seconds, while running on the local fallback. Defaults to `300`.    |
+
+To find the local IP of your Tydom bridge, the most reliable method is to open your router or internet box administration page and look at the DHCP/client list. Search for a device named `Tydom`, `Delta Dore`, or for a MAC address starting with `00:1A:25`, which matches the usual Tydom username prefix. You can then verify the IP from a terminal with:
+
+```sh
+curl -k "https://192.168.0.X/mediation/client?mac=001A25XXXXXX&appli=1"
+```
+
+A `401 Unauthorized` response is expected and means the Tydom bridge is reachable locally.
+
+Tydom 2.0 firmware can sometimes have trouble dealing with multiple local clients, locking you away from the mobile app. If the mobile app stops working locally during tests, stop Homebridge and wait a short moment before trying again.
+
+### Legacy TLS/OpenSSL for local mode
+
+The local Tydom bridge uses a self-signed certificate, and some firmware versions also require legacy TLS renegotiation. For local mode, `NODE_TLS_REJECT_UNAUTHORIZED=0` is usually required. On recent Node.js/OpenSSL versions, you may also see an error such as `ERR_SSL_UNSAFE_LEGACY_RENEGOTIATION_DISABLED`; in that case, configure OpenSSL legacy renegotiation for the Homebridge Node.js process.
+
+Only enable this for a trusted Homebridge process that needs local Tydom access.
+
+#### Case 1: You start Homebridge yourself from a shell
+
+Create an OpenSSL configuration file:
+
+```sh
+mkdir -p "$HOME/.homebridge"
+cat > "$HOME/.homebridge/openssl-legacy.cnf" <<'EOF'
+openssl_conf = openssl_init
+
+[openssl_init]
+ssl_conf = ssl_sect
+
+[ssl_sect]
+system_default = system_default_sect
+
+[system_default_sect]
+Options = UnsafeLegacyRenegotiation
+EOF
+```
+
+Then start Homebridge with the two Node/OpenSSL environment variables added to your usual command:
+
+```sh
+NODE_TLS_REJECT_UNAUTHORIZED=0 \
+NODE_OPTIONS="--openssl-shared-config --openssl-config=$HOME/.homebridge/openssl-legacy.cnf" \
+homebridge
+```
+
+If you usually pass a custom Homebridge user directory, keep it at the end of the same command:
+
+```sh
+NODE_TLS_REJECT_UNAUTHORIZED=0 \
+NODE_OPTIONS="--openssl-shared-config --openssl-config=$HOME/.homebridge/openssl-legacy.cnf" \
+homebridge -U /path/to/homebridge
+```
+
+#### Case 2: You use the Homebridge Raspberry Pi image
+
+On the official Homebridge Raspberry Pi image, open the terminal from the Homebridge web interface and run the following commands. They create the OpenSSL configuration in `/var/lib/homebridge` and add the environment variables to the `homebridge` systemd service.
+
+```sh
+sudo tee /var/lib/homebridge/openssl-legacy.cnf > /dev/null <<'EOF'
+openssl_conf = openssl_init
+
+[openssl_init]
+ssl_conf = ssl_sect
+
+[ssl_sect]
+system_default = system_default_sect
+
+[system_default_sect]
+Options = UnsafeLegacyRenegotiation
+EOF
+
+sudo mkdir -p /etc/systemd/system/homebridge.service.d
+sudo tee /etc/systemd/system/homebridge.service.d/override.conf > /dev/null <<'EOF'
+[Service]
+Environment="NODE_TLS_REJECT_UNAUTHORIZED=0"
+Environment="NODE_OPTIONS=--openssl-shared-config --openssl-config=/var/lib/homebridge/openssl-legacy.cnf"
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl restart homebridge
+```
+
+After the restart, check the Homebridge logs from the web interface. If the local Tydom connection works, you should see the plugin connect to `localHostname` when the primary host is unavailable.
+
+To remove this OpenSSL override later:
+
+```sh
+sudo rm /etc/systemd/system/homebridge.service.d/override.conf
+sudo systemctl daemon-reload
+sudo systemctl restart homebridge
+```
 
 ### Configurations
 
-| **Field**          | **Type**            | **Description**             |                                            |
-| ------------------ | ------------------- | --------------------------- | ------------------------------------------ |
-| hostname           | `string`            | Tydom hostname              |                                            |
-| username           | `string`            | Tydom username              |                                            |
-| password           | `string`            | Tydom password              |                                            |
-| settings           | `Record<string, ?>` | Device settings (overrides) |                                            |
-| includedDevices    | `Array<string>`     | number>                     | Include only devices with following ids    |
-| excludedDevices    | `Array<string>`     | number>                     | Exclude all devices with following ids     |
-| includedCategories | `Array<string>`     | number>                     | Include only categories with following ids |
-| excludedCategories | `Array<string>`     | number>                     | Exclude all categories with following ids  |
+| **Field**            | **Type**            | **Description**             |                                            |
+| -------------------- | ------------------- | --------------------------- | ------------------------------------------ |
+| hostname             | `string`            | Tydom hostname              |                                            |
+| localHostname        | `string`            | Local Tydom fallback host   | Optional local IP or hostname              |
+| primaryRetryInterval | `number`            | Primary retry interval      | Seconds, defaults to `300`                 |
+| username             | `string`            | Tydom username              |                                            |
+| password             | `string`            | Tydom password              |                                            |
+| settings             | `Record<string, ?>` | Device settings (overrides) |                                            |
+| includedDevices      | `Array<string>`     | number>                     | Include only devices with following ids    |
+| excludedDevices      | `Array<string>`     | number>                     | Exclude all devices with following ids     |
+| includedCategories   | `Array<string>`     | number>                     | Include only categories with following ids |
+| excludedCategories   | `Array<string>`     | number>                     | Exclude all categories with following ids  |
 
 - The `settings` field enables you to override the name or homekit category of your Tydom device (check homebridge log for the device ids).
 

--- a/README.md
+++ b/README.md
@@ -147,12 +147,14 @@ They take precedence over the corresponding config fields.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `hostname` | `string` | — | `mediation.tydom.com` for the relay, or your gateway's LAN address (see [Connecting locally](#connecting-locally)). Required. |
+| `localHostname` | `string` | — | Optional LAN address for the same gateway. Used automatically when `hostname` is unavailable. |
 | `username` | `string` | — | Gateway MAC address, e.g. `001A25123456`. This is what selects the house — see [If your account has several houses](#if-your-account-has-several-houses). Required. |
 | `email` | `string` | — | Delta Dore account e-mail. Set it to have the gateway password fetched for you, which also changes what `password` below means. See [Finding your credentials](#finding-your-credentials). |
 | `password` | `string` | — | Your Delta Dore account password if `email` is set, otherwise the gateway's own password. Required, unless supplied via the environment. |
 | `pin` | `string` | — | TYXAL+ alarm PIN. Without it the alarm reports its state but cannot be armed or disarmed. |
 | `locale` | `"fr" \| "en"` | `"fr"` | Language of the labels Delta Dore supplies for zones, detectors and thermostat modes. |
 | `refreshInterval` | `number` | `14400` | Seconds between full state refreshes. The gateway pushes changes as they happen, so this is only a safety net; clamped to a minimum of 60. |
+| `primaryRetryInterval` | `number` | `300` | Seconds between relay recovery probes while the local fallback is active; clamped to a minimum of 30. |
 | `staleAfter` | `number` | `300` | Seconds a device reading is served from memory before HomeKit's next query triggers a background re-read. `0` reads through on every query, as releases before 0.30 did. See [Reading state](#reading-state). |
 | `includedDevices` | `string[]` | `[]` | If non-empty, ignore every device not listed. |
 | `excludedDevices` | `string[]` | `[]` | Devices to leave out, applied after the include list. |
@@ -191,6 +193,25 @@ Pointing `hostname` at your gateway's IP (e.g. `192.168.0.42`) skips Delta Dore'
 
 - The gateway serves a self-signed certificate, so Node must be started with `NODE_TLS_REJECT_UNAUTHORIZED=0`.
 - Tydom 2.0 firmware sometimes copes badly with several local clients at once, and can lock you out of the mobile app.
+
+To keep the relay as the primary route and use the LAN only during an outage, configure both endpoints:
+
+```json
+{
+  "platform": "Tydom",
+  "hostname": "mediation.tydom.com",
+  "localHostname": "192.168.0.42",
+  "primaryRetryInterval": 300,
+  "username": "001A25123456",
+  "password": "YourPassw0rd"
+}
+```
+
+The plugin tries `hostname` first at startup. If it cannot connect, or if that connection later drops, it opens one managed connection to `localHostname`. While local is active it probes the primary endpoint every `primaryRetryInterval` seconds without interrupting the working local socket, then switches back and re-syncs after a successful probe.
+
+Reads which fail because the socket disappeared are retried after the switch. A write is retried only when it was rejected before anything reached the socket; a timeout is deliberately not replayed because the gateway may already have applied the command.
+
+The local certificate caveat applies to fallback too. With a trusted LAN gateway, start Homebridge with `NODE_TLS_REJECT_UNAUTHORIZED=0`; the development script `pnpm dev:homebridge:insecure` does that for the isolated `.homebridge` setup. Some older firmware also needs OpenSSL legacy renegotiation — see the [local fallback test protocol](docs/local-fallback-testing.md#legacy-tls-renegotiation).
 
 ## Device settings
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -13,6 +13,21 @@
         "required": true,
         "default": "mediation.tydom.com"
       },
+      "localHostname": {
+        "title": "Local Tydom hostname",
+        "description": "Optional local Tydom IP or hostname used as a fallback when the primary hostname is unavailable.",
+        "type": "string",
+        "required": false,
+        "default": ""
+      },
+      "primaryRetryInterval": {
+        "title": "Primary retry interval",
+        "description": "Seconds between attempts to restore the primary hostname while local fallback is active.",
+        "type": "number",
+        "required": false,
+        "default": 300,
+        "minimum": 30
+      },
       "username": {
         "title": "Tydom username",
         "type": "string",
@@ -40,5 +55,5 @@
       }
     }
   },
-  "form": ["hostname", "username", "password", "settings"]
+  "form": ["hostname", "localHostname", "primaryRetryInterval", "username", "password", "settings"]
 }

--- a/config.schema.json
+++ b/config.schema.json
@@ -14,6 +14,11 @@
         "default": "mediation.tydom.com",
         "description": "Leave as `mediation.tydom.com` to reach the gateway through Delta Dore's relay. To talk to it directly on your LAN, use its IP address or `.local` name — faster and it keeps working when the relay is down, but the gateway serves a self-signed certificate, so Node must be started with `NODE_TLS_REJECT_UNAUTHORIZED=0`."
       },
+      "localHostname": {
+        "title": "Local fallback hostname",
+        "type": "string",
+        "description": "Optional LAN IP address or `.local` name for the same Tydom gateway. The plugin uses it when the primary hostname is unavailable, keeps checking the primary in the background, and switches back after it recovers. Local gateways use a self-signed certificate, so Node normally needs `NODE_TLS_REJECT_UNAUTHORIZED=0`."
+      },
       "username": {
         "title": "Username",
         "type": "string",
@@ -54,6 +59,13 @@
         "default": 14400,
         "minimum": 60,
         "description": "How often to ask the gateway to re-push the state of everything. The gateway pushes changes as they happen, so this is only a safety net against a missed message; the default is four hours. Values below 60 seconds are clamped."
+      },
+      "primaryRetryInterval": {
+        "title": "Primary retry interval (seconds)",
+        "type": "integer",
+        "default": 300,
+        "minimum": 30,
+        "description": "How often to check whether the primary hostname has recovered while the local fallback is active. The default is five minutes; values below 30 seconds are clamped."
       },
       "staleAfter": {
         "title": "Reading lifetime (seconds)",
@@ -129,7 +141,7 @@
     {
       "type": "fieldset",
       "title": "Connection",
-      "items": ["hostname", "username", "email", "password"]
+      "items": ["hostname", "localHostname", "username", "email", "password"]
     },
     {
       "type": "fieldset",
@@ -180,7 +192,14 @@
       "type": "fieldset",
       "title": "Advanced",
       "expandable": true,
-      "items": ["locale", "refreshInterval", "staleAfter", "debug", "settings"]
+      "items": [
+        "locale",
+        "refreshInterval",
+        "primaryRetryInterval",
+        "staleAfter",
+        "debug",
+        "settings"
+      ]
     }
   ]
 }

--- a/docs/local-fallback-testing.md
+++ b/docs/local-fallback-testing.md
@@ -1,0 +1,134 @@
+# Local and fallback test protocol
+
+This protocol exercises a working-tree build in an isolated Homebridge directory. It covers direct LAN access, startup fallback, runtime fallback, primary restoration and shutdown. Do not reuse the bridge identity or cache of a production Homebridge instance.
+
+## Prerequisites
+
+- Node.js 22, 24 or 26.
+- pnpm 11, matching the version declared by this repository.
+- The LAN address of the Tydom gateway.
+- Its MAC-form username (`001A25XXXXXX`) and gateway password, or a Delta Dore account e-mail and password.
+
+From the repository root:
+
+```sh
+pnpm install --frozen-lockfile
+pnpm test
+pnpm build
+mkdir -p .homebridge
+```
+
+Create `.homebridge/config.json` with a bridge identity used only for this test:
+
+```json
+{
+  "bridge": {
+    "name": "Homebridge Tydom Test",
+    "username": "0E:21:1B:E7:27:C9",
+    "port": 53619,
+    "pin": "031-45-154"
+  },
+  "accessories": [],
+  "platforms": [
+    {
+      "platform": "Tydom",
+      "hostname": "mediation.tydom.com",
+      "localHostname": "192.168.0.42",
+      "primaryRetryInterval": 30,
+      "username": "001A25XXXXXX",
+      "password": "YourPassw0rd",
+      "debug": true
+    }
+  ]
+}
+```
+
+Do not commit this file. A base64-encoded `HOMEBRIDGE_TYDOM_PASSWORD` may be used instead of storing the password in it.
+
+## Direct LAN connection
+
+Set `hostname` to the LAN address and remove `localHostname`, then run:
+
+```sh
+pnpm run clean
+DEBUG=homebridge-tydom,tydom-client pnpm dev:homebridge:insecure
+```
+
+Expected results:
+
+- the client connects to the LAN address;
+- `/ping` and the three discovery requests succeed;
+- the accessories are scanned and registered;
+- stopping Homebridge releases the socket and timers.
+
+A certificate error usually means Homebridge was not started with the `:insecure` script. A timeout or `ECONNREFUSED` points to an incorrect or unreachable LAN address.
+
+## Startup fallback
+
+Use an intentionally invalid primary hostname while keeping the correct LAN address:
+
+```json
+{
+  "hostname": "mediation.tydom.invalid",
+  "localHostname": "192.168.0.42",
+  "primaryRetryInterval": 30
+}
+```
+
+Start the isolated bridge again. The log should show one failed primary connection followed by a successful local connection and a completed scan. It must not show an independent reconnect from the retired primary client.
+
+## Runtime fallback
+
+Restore `hostname` to `mediation.tydom.com`, start Homebridge, and wait for the primary connection. Then temporarily block Internet access while leaving the LAN available.
+
+Expected sequence:
+
+1. The active primary reports a disconnect.
+2. One controller-owned retry is scheduled.
+3. The local endpoint connects and state is re-synchronised once.
+4. HomeKit reads and writes continue over the LAN.
+
+Do not validate this by repeatedly toggling a device while the socket is failing: a command whose response is lost is intentionally not replayed, because applying it twice can be unsafe.
+
+## Primary restoration
+
+With local fallback active, restore Internet access. At the next `primaryRetryInterval` the log should show a primary check. The local socket stays active until the primary `/ping` succeeds. The controller then switches atomically, closes the retired local client and performs one queued re-sync.
+
+Useful log fragments are:
+
+```text
+Checking if primary Tydom hostname=mediation.tydom.com is available again...
+Successfully connected to primary Tydom hostname=mediation.tydom.com
+Restored primary Tydom hostname=mediation.tydom.com, switching back from local fallback
+```
+
+## Shutdown during recovery
+
+Block the primary, wait until local fallback is active or a reconnect is pending, then stop Homebridge with `Ctrl+C`. No new connection or refresh line should appear afterwards, and the process should exit without being killed.
+
+## Legacy TLS renegotiation
+
+Some older gateways fail locally with `ERR_SSL_UNSAFE_LEGACY_RENEGOTIATION_DISABLED`. For a trusted, isolated test only, create `.homebridge/openssl-legacy.cnf`:
+
+```ini
+openssl_conf = openssl_init
+
+[openssl_init]
+ssl_conf = ssl_sect
+
+[ssl_sect]
+system_default = system_default_sect
+
+[system_default_sect]
+Options = UnsafeLegacyRenegotiation
+```
+
+Then launch with:
+
+```sh
+NODE_OPTIONS="--openssl-shared-config --openssl-config=$PWD/.homebridge/openssl-legacy.cnf" \
+  DEBUG=homebridge-tydom,tydom-client \
+  pnpm dev:homebridge:insecure
+```
+
+Keep this override limited to the Homebridge process which needs the legacy gateway.

--- a/docs/protocole-test-homebridge.md
+++ b/docs/protocole-test-homebridge.md
@@ -1,0 +1,313 @@
+# Protocole de test Homebridge Tydom local et fallback
+
+Ce protocole permet de tester une version locale de `homebridge-tydom` dans un Homebridge isolé, sans impacter une installation Homebridge principale. Il couvre deux scénarios principaux : connexion directe à la box Tydom locale, puis fallback du host distant vers le host local.
+
+## Objectifs
+
+- Vérifier que le plugin compilé depuis ce dépôt est bien chargé par Homebridge.
+- Vérifier que la connexion locale à la box Tydom fonctionne avec `hostname` pointant vers l'IP locale.
+- Vérifier que `localHostname` est utilisé quand `hostname` est indisponible.
+- Vérifier que le plugin retente ensuite le `hostname` distant et rebascule dessus lorsqu'il redevient disponible.
+- Observer les logs de bascule et les éventuelles limites liées au certificat TLS local.
+
+## Pré-requis
+
+- Node.js compatible avec le projet : Node 20, 22 ou 24 recommandé.
+- `pnpm` disponible directement, via `npm`, ou via Corepack.
+- Une box Tydom joignable depuis la machine de test.
+- L'adresse IP locale de la box Tydom, par exemple `192.168.0.X`.
+- Les identifiants Tydom :
+  - `username` : adresse MAC Tydom sous la forme `001A25XXXXXX`.
+  - `password` : mot de passe Tydom récupéré depuis l'application ou via inspection réseau.
+
+## Préparer le Homebridge de test
+
+Depuis la racine du dépôt :
+
+```sh
+cd /Users/cedriceugeni/dev/perso/homebridge-tydom
+pnpm install --frozen-lockfile
+pnpm run build
+mkdir -p .homebridge
+```
+
+Si `pnpm` est déjà installé, `corepack` n'est pas nécessaire. Vérifier avec :
+
+```sh
+pnpm -v
+```
+
+Si `pnpm` n'est pas disponible, l'installer avec `npm` en utilisant la version déclarée par le projet :
+
+```sh
+npm install -g pnpm@10.29.3
+```
+
+Alternative sans installation globale :
+
+```sh
+npx pnpm@10.29.3 install --frozen-lockfile
+npx pnpm@10.29.3 run build
+```
+
+Le script `pnpm start` lance Homebridge avec ces options :
+
+```sh
+NODE_TLS_REJECT_UNAUTHORIZED=0 homebridge -D -U ./.homebridge -P .
+```
+
+Cela signifie :
+
+- `NODE_TLS_REJECT_UNAUTHORIZED=0` autorise le certificat auto-signe de la box Tydom locale.
+- `-D` active le mode debug Homebridge.
+- `-U ./.homebridge` utilise un dossier Homebridge local et isole les accessoires/cache de test.
+- `-P .` force Homebridge à charger le plugin depuis le dépôt courant.
+
+## Config de base
+
+Créer le fichier `.homebridge/config.json` avec un bridge de test distinct :
+
+```json
+{
+  "bridge": {
+    "name": "Homebridge Tydom Test",
+    "username": "0E:21:1B:E7:27:C9",
+    "port": 53619,
+    "pin": "031-45-154"
+  },
+  "accessories": [],
+  "platforms": [
+    {
+      "platform": "Tydom",
+      "hostname": "mediation.tydom.com",
+      "localHostname": "192.168.0.X",
+      "primaryRetryInterval": 300,
+      "username": "001A25XXXXXX",
+      "password": "YourPassw0rd",
+      "debug": true
+    }
+  ]
+}
+```
+
+Remplacer :
+
+- `192.168.0.X` par l'IP locale de la box Tydom.
+- `001A25XXXXXX` par le username Tydom.
+- `YourPassw0rd` par le mot de passe Tydom.
+
+Si le mot de passe ne doit pas apparaitre dans le fichier, utiliser plutôt la variable d'environnement `HOMEBRIDGE_TYDOM_PASSWORD` en base64 et laisser `password` vide ou factice selon la config Homebridge :
+
+```sh
+export HOMEBRIDGE_TYDOM_PASSWORD="$(printf '%s' 'YourPassw0rd' | base64)"
+```
+
+## Test 1 - Connexion locale directe
+
+Ce test vérifie d'abord que la box locale répond avec le protocole supporté par `tydom-client`.
+
+Dans `.homebridge/config.json`, mettre `hostname` directement sur l'IP locale et supprimer temporairement `localHostname` ou le laisser identique :
+
+```json
+{
+  "platform": "Tydom",
+  "hostname": "192.168.0.X",
+  "username": "001A25XXXXXX",
+  "password": "YourPassw0rd",
+  "debug": true
+}
+```
+
+Nettoyer le cache Homebridge de test, puis lancer :
+
+```sh
+pnpm run clean
+DEBUG=homebridge-tydom,tydom-client pnpm start
+```
+
+Résultat attendu :
+
+- Homebridge démarre avec le dossier `.homebridge`.
+- Les logs `tydom-client` montrent une connexion vers `192.168.0.X`.
+- Les accessoires Tydom sont scannés et ajoutés.
+- Le QR code ou le pin Homebridge permet d'ajouter ce bridge de test dans l'app Maison.
+
+Critères d'échec typiques :
+
+- Erreur de certificat : vérifier que le lancement passe bien par `pnpm start`, car le script définit `NODE_TLS_REJECT_UNAUTHORIZED=0`.
+- Erreur `fetch failed` avec `ERR_SSL_UNSAFE_LEGACY_RENEGOTIATION_DISABLED` : certaines box Tydom locales utilisent une renégociation TLS héritée désactivée par OpenSSL/Node. Voir la section suivante.
+- Timeout ou `ECONNREFUSED` : vérifier que l'IP locale est correcte et accessible depuis la machine.
+- Authentification refusée : vérifier `username` et `password`.
+
+### Autoriser la renégociation TLS héritée
+
+Si les logs affichent une erreur de ce type :
+
+```text
+TypeError: fetch failed
+ERR_SSL_UNSAFE_LEGACY_RENEGOTIATION_DISABLED
+unsafe legacy renegotiation disabled
+```
+
+Créer un fichier `.homebridge/openssl-legacy.cnf` :
+
+```ini
+openssl_conf = openssl_init
+
+[openssl_init]
+ssl_conf = ssl_sect
+
+[ssl_sect]
+system_default = system_default_sect
+
+[system_default_sect]
+Options = UnsafeLegacyRenegotiation
+```
+
+Puis lancer Homebridge avec `NODE_OPTIONS` en plus du debug :
+
+```sh
+NODE_OPTIONS="--openssl-shared-config --openssl-config=$PWD/.homebridge/openssl-legacy.cnf" DEBUG=homebridge-tydom,tydom-client pnpm start
+```
+
+Cette option doit rester limitée au Homebridge de test ou a un environnement de confiance, car elle assouplit le comportement TLS de Node pour permettre la communication avec l'ancien serveur TLS local de la box.
+
+## Test 2 - Fallback au démarrage
+
+Ce test force l'échec du host principal pour vérifier que `localHostname` prend le relais.
+
+Dans `.homebridge/config.json`, mettre un host distant volontairement invalide :
+
+```json
+{
+  "platform": "Tydom",
+  "hostname": "mediation.tydom.invalid",
+  "localHostname": "192.168.0.X",
+  "username": "001A25XXXXXX",
+  "password": "YourPassw0rd",
+  "debug": true
+}
+```
+
+Relancer depuis un état propre :
+
+```sh
+pnpm run clean
+DEBUG=homebridge-tydom,tydom-client pnpm start
+```
+
+Résultat attendu :
+
+- Le plugin tente d'abord `mediation.tydom.invalid`.
+- Les logs indiquent l'échec de connexion au host `primary`.
+- Le plugin crée ensuite un client `local` avec `192.168.0.X`.
+- Homebridge termine le scan des accessoires depuis la connexion locale.
+- Tant que le client actif est local, le plugin retente le `hostname` principal toutes les `primaryRetryInterval` secondes, `300` secondes par défaut.
+
+Exemples de logs à rechercher :
+
+```text
+Failed to connect to primary Tydom hostname=...
+Creating local tydom client ... hostname=192.168.0.X
+Successfully connected to local Tydom hostname=192.168.0.X
+Scheduling primary Tydom retry for hostname=mediation.tydom.invalid in 300s while using local fallback
+```
+
+Pour tester plus vite le retour distant dans le test suivant, régler temporairement `primaryRetryInterval` à `30`.
+
+## Test 3 - Fallback pendant l'exécution
+
+Ce test est optionnel et plus délicat, car il faut provoquer une panne du chemin distant alors que Homebridge tourne.
+
+Configuration de départ :
+
+```json
+{
+  "platform": "Tydom",
+  "hostname": "mediation.tydom.com",
+  "localHostname": "192.168.0.X",
+  "username": "001A25XXXXXX",
+  "password": "YourPassw0rd",
+  "debug": true
+}
+```
+
+Lancer Homebridge :
+
+```sh
+pnpm run clean
+DEBUG=homebridge-tydom,tydom-client pnpm start
+```
+
+Méthodes possibles pour provoquer la panne distante :
+
+- Couper temporairement l'accès Internet de la machine tout en gardant le réseau local actif.
+- Bloquer temporairement `mediation.tydom.com` avec un pare-feu local.
+- Modifier la config pour un host distant invalide, puis redémarrer Homebridge. Cette variante teste surtout le fallback au démarrage.
+
+Résultat attendu :
+
+- Une déconnexion du client `primary` est détectée.
+- Le contrôleur planifie une reconnexion.
+- La reconnexion préfère le host local après une panne du primary.
+- Les lectures HomeKit continuent via la box locale après la bascule.
+- Pendant l'utilisation du local, le contrôleur sonde périodiquement le host distant et rebascule dessus dès qu'il répond de nouveau.
+
+Logs attendus après rétablissement du distant :
+
+```text
+Checking if primary Tydom hostname=mediation.tydom.com is available again...
+Successfully connected to primary Tydom hostname=mediation.tydom.com
+Restored primary Tydom hostname=mediation.tydom.com, switching back from local fallback
+```
+
+Attention : les écritures non idempotentes ne sont pas rejouées aveuglément après une bascule. Par exemple, un ordre `TOGGLE` de garage ne doit pas être envoyé deux fois si la première requête a potentiellement atteint Tydom mais que la réponse s'est perdue.
+
+## Commandes utiles
+
+Compiler le plugin local :
+
+```sh
+pnpm run build
+```
+
+Lancer Homebridge de test :
+
+```sh
+DEBUG=homebridge-tydom,tydom-client pnpm start
+```
+
+Nettoyer les accessoires et le cache persistants du Homebridge de test :
+
+```sh
+pnpm run clean
+```
+
+Vérifier le typecheck :
+
+```sh
+pnpm run check
+```
+
+Lancer la validation complète du dépôt :
+
+```sh
+pnpm run test
+```
+
+## Notes de prudence
+
+- Ne pas utiliser le même `bridge.username` que le Homebridge principal.
+- Ne pas laisser deux Homebridge piloter la même box Tydom en local pendant longtemps si la box semble instable.
+- Pour un test HomeKit réel sur macOS, préférer ce setup local avec `.homebridge` plutôt qu'un conteneur Docker, car Bonjour/mDNS fonctionne mieux hors conteneur.
+- Ne pas commiter `.homebridge/config.json` s'il contient des identifiants.
+
+## Nettoyage après test
+
+Arrêter Homebridge avec `Ctrl+C`, puis nettoyer les données locales si nécessaire :
+
+```sh
+pnpm run clean
+```
+
+Pour repartir de zéro côté app Maison, supprimer le bridge de test depuis l'application Maison avant de le réajouter.

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,8 @@ export type TydomLocale = Locale;
 /** The platform's configuration, parsed once and normalised. */
 export type TydomConfig = {
   hostname: string;
+  /** Optional LAN endpoint used while the primary endpoint is unavailable. */
+  localHostname: string | undefined;
   username: string;
   /**
    * The password — of the account when `email` is set, of the gateway when it
@@ -54,6 +56,8 @@ export type TydomConfig = {
   excludedCategories: (string | number)[];
   /** User-facing seconds become milliseconds at the boundary. */
   refreshIntervalMs: number;
+  /** How often the primary endpoint is probed while the LAN fallback is active. */
+  primaryRetryIntervalMs: number;
   /**
    * How long a device reading is served from memory before a read repairs it
    * in the background. `0` reads through on every HomeKit query, which is what
@@ -71,8 +75,11 @@ export type TydomConfig = {
 
 export const DEFAULT_REFRESH_INTERVAL_MS = 4 * 60 * 60 * 1000;
 export const DEFAULT_STALE_AFTER_MS = 5 * 60 * 1000;
+export const DEFAULT_PRIMARY_RETRY_INTERVAL_MS = 5 * 60 * 1000;
 /** A refresh is a full `POST /refresh/all`; hammering the gateway helps nobody. */
 export const MIN_REFRESH_INTERVAL_MS = 60 * 1000;
+/** Repeated TLS handshakes are not a useful way to monitor the relay. */
+export const MIN_PRIMARY_RETRY_INTERVAL_MS = 30 * 1000;
 
 const asArray = (value: unknown): (string | number)[] =>
   Array.isArray(value) ? (value as (string | number)[]) : [];
@@ -201,6 +208,11 @@ export const parseConfig = (config: PlatformConfig, env: ConfigEnv = process.env
     warnings.push(message);
   };
   const hostname = asString(config["hostname"]);
+  const configuredLocalHostname = asString(config["localHostname"]);
+  const localHostname =
+    configuredLocalHostname && configuredLocalHostname !== hostname
+      ? configuredLocalHostname
+      : undefined;
   const username = asString(config["username"]);
 
   // The base64-encoded env vars take precedence, so a shared config file need
@@ -241,6 +253,13 @@ export const parseConfig = (config: PlatformConfig, env: ConfigEnv = process.env
     ? Math.max(MIN_REFRESH_INTERVAL_MS, refreshSeconds * 1000)
     : DEFAULT_REFRESH_INTERVAL_MS;
 
+  const primaryRetrySeconds = Number(
+    config["primaryRetryInterval"] ?? DEFAULT_PRIMARY_RETRY_INTERVAL_MS / 1000,
+  );
+  const primaryRetryIntervalMs = Number.isFinite(primaryRetrySeconds)
+    ? Math.max(MIN_PRIMARY_RETRY_INTERVAL_MS, primaryRetrySeconds * 1000)
+    : DEFAULT_PRIMARY_RETRY_INTERVAL_MS;
+
   const staleSeconds = Number(config["staleAfter"] ?? DEFAULT_STALE_AFTER_MS / 1000);
   const staleAfterMs =
     Number.isFinite(staleSeconds) && staleSeconds >= 0
@@ -249,6 +268,7 @@ export const parseConfig = (config: PlatformConfig, env: ConfigEnv = process.env
 
   return {
     hostname,
+    localHostname,
     username,
     password,
     email,
@@ -262,6 +282,7 @@ export const parseConfig = (config: PlatformConfig, env: ConfigEnv = process.env
     includedCategories: asArray(config["includedCategories"]),
     excludedCategories: asArray(config["excludedCategories"]),
     refreshIntervalMs,
+    primaryRetryIntervalMs,
     staleAfterMs,
     warnings,
   };

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -24,6 +24,7 @@ import { stringifyError } from "src/utils/error";
 import TydomClient, {
   createClient as createTydomClient,
   type TydomHttpMessage,
+  type TydomRequestBody,
   type TydomResponse,
 } from "tydom-client";
 
@@ -42,57 +43,56 @@ export type ControllerNotificationPayload = {
 };
 
 const DEFAULT_REFRESH_INTERVAL_SEC = 4 * 60 * 60; // 4 hours
+const DEFAULT_PRIMARY_RETRY_INTERVAL_SEC = 5 * 60; // 5 minutes
+const RECONNECT_BASE_DELAY_MS = 5 * 1000;
+const MAX_RECONNECT_DELAY_MS = 5 * 60 * 1000;
+
+type TydomConnectionTarget = {
+  hostname: string;
+  type: "primary" | "local";
+};
+
+type TydomClientOperation<T> = (client: TydomClient) => Promise<T>;
+
+type TydomFailoverOptions = {
+  retryOperation?: boolean | ((err: unknown) => boolean);
+};
 
 export default class TydomController extends EventEmitter {
   public client: TydomClient;
   public config: TydomPlatformConfig;
   public log: Logging;
+  private activeClient?: TydomClient;
+  private activeHostname?: string;
+  private activeTargetType?: TydomConnectionTarget["type"];
+  private readonly password: string;
+  private failoverPromise?: Promise<void>;
   private devices = new Map<string, Categories>();
   private state = new Map<string, unknown>();
   private refreshInterval?: NodeJS.Timeout;
+  private reconnectTimeout?: NodeJS.Timeout;
+  private primaryRetryTimeout?: NodeJS.Timeout;
+  private reconnectAttempt = 0;
+  private closingClients = new WeakSet<TydomClient>();
   private hasConnectedOnce = false;
   constructor(log: Logging, config: TydomPlatformConfig) {
     super();
     this.config = config;
     this.log = log;
-    const { hostname, username, password: configPassword } = config;
+    const { hostname, localHostname, username, password: configPassword } = config;
     assert(hostname, 'Missing "hostname" config field for platform');
     assert(username, 'Missing "username" config field for platform');
     const password = HOMEBRIDGE_TYDOM_PASSWORD ? decode(HOMEBRIDGE_TYDOM_PASSWORD) : configPassword;
     assert(password, 'Missing "password" config field for platform');
-    this.log.info(
-      `Creating tydom client with username=${chalkString(username)} and hostname=${chalkString(hostname)}`,
-    );
-    this.client = createTydomClient({ username, password, hostname, followUpDebounce: 500 });
-    this.client.on("message", (message: TydomHttpMessage) => {
-      try {
-        this.handleMessage(message);
-      } catch (err) {
-        this.log.error(
-          `Encountered an uncaught error=${stringifyError(err as Error)} while processing message=${chalkJson(message)}"`,
-        );
-      }
-    });
-    this.client.on("connect", () => {
-      this.log.info(
-        `Successfully connected to Tydom hostname=${chalkString(hostname)} with username=${chalkString(username)}`,
+    this.password = password;
+    this.client = this.createClientFacade();
+    if (localHostname && process.env.NODE_TLS_REJECT_UNAUTHORIZED !== "0") {
+      this.log.warn(
+        `Local Tydom fallback hostname=${chalkString(
+          localHostname,
+        )} is configured but NODE_TLS_REJECT_UNAUTHORIZED is not set to 0; the local self-signed certificate may be rejected`,
       );
-      if (this.hasConnectedOnce) {
-        this.log.warn(`Reconnected to Tydom hostname=${chalkString(hostname)}, re-syncing state...`);
-        this.resync().catch((err: unknown) => {
-          this.log.error(`Failed to re-sync after reconnection: ${stringifyError(err as Error)}`);
-        });
-      }
-      this.emit("connect");
-    });
-    this.client.on("disconnect", () => {
-      this.log.warn(`Disconnected from Tydom hostname=${chalkString(hostname)}"`);
-      if (this.refreshInterval) {
-        clearInterval(this.refreshInterval);
-        this.refreshInterval = undefined;
-      }
-      this.emit("disconnect");
-    });
+    }
   }
   getUniqueId(deviceId: number, endpointId: number): string {
     return deviceId === endpointId ? `${deviceId}` : `${deviceId}:${endpointId}`;
@@ -103,15 +103,8 @@ export default class TydomController extends EventEmitter {
   }
   async connect(): Promise<void> {
     const { hostname, username } = this.config;
-    debug(`Connecting to hostname=${chalkString(hostname)}...`);
     try {
-      await this.client.connect();
-      await asyncWait(250);
-      // Initial intro handshake
-      await this.client.get("/ping");
-      this.hasConnectedOnce = true;
-      // await asyncWait(250);
-      // await this.client.put('/configs/gateway/api_mode');
+      await this.establishConnection(false);
     } catch (err) {
       this.log.error(`Failed to connect to Tydom hostname=${hostname} with username="${username}"`);
       throw err;
@@ -138,7 +131,7 @@ export default class TydomController extends EventEmitter {
       try {
         await this.refresh();
       } catch (err) {
-        debug(`Failed interval refresh with err ${err}`);
+        debug(`Failed interval refresh with err ${stringifyError(err as Error)}`);
       }
     }, refreshInterval * 1000);
     Object.assign(this.state, { config, groups, meta });
@@ -166,8 +159,8 @@ export default class TydomController extends EventEmitter {
       const uniqueId = this.getUniqueId(deviceId, endpointId);
       const { metadata } = getEndpointDetailsFromMeta(endpoint, meta);
       const groupId = getEndpointGroupIdFromGroups(endpoint, groups);
-      const group = groupId ? configGroups.find(({ id }) => id === groupId) : undefined;
-      const deviceSettings = settings[deviceId] || {};
+      const group = groupId !== null ? configGroups.find(({ id }) => id === groupId) : undefined;
+      const deviceSettings = settings[deviceId] ?? {};
       const categoryFromSettings = deviceSettings.category;
       // @TODO resolve endpoint productType
       this.log.info(
@@ -233,6 +226,276 @@ export default class TydomController extends EventEmitter {
     debug(`Refreshing Tydom controller ...`);
     await this.client.post("/refresh/all");
   }
+  private createClientFacade(): TydomClient {
+    return {
+      close: (): void => {
+        this.clearPrimaryRetryTimeout();
+        this.clearReconnectTimeout();
+        if (this.activeClient) {
+          this.closeClient(this.activeClient);
+        }
+      },
+      connect: async (): Promise<unknown> => {
+        await this.connect();
+        return undefined;
+      },
+      delete: async <T extends TydomResponse = TydomResponse>(url: string): Promise<T> =>
+        await this.runWithFailover((client) => client.delete<T>(url), `DELETE ${url}`, {
+          retryOperation: (err) => this.canRetryMutationAfterFailover(err),
+        }),
+      get: async <T extends TydomResponse = TydomResponse>(url: string): Promise<T> =>
+        await this.runWithFailover((client) => client.get<T>(url), `GET ${url}`),
+      post: async <T extends TydomResponse = TydomResponse>(
+        url: string,
+        body?: TydomRequestBody,
+      ): Promise<T> =>
+        await this.runWithFailover((client) => client.post<T>(url, body), `POST ${url}`, {
+          retryOperation: (err) => this.canRetryMutationAfterFailover(err),
+        }),
+      put: async <T extends TydomResponse = TydomResponse>(url: string, body?: TydomRequestBody): Promise<T> =>
+        await this.runWithFailover((client) => client.put<T>(url, body), `PUT ${url}`, {
+          retryOperation: (err) => this.canRetryMutationAfterFailover(err),
+        }),
+      command: async <T extends TydomResponse = TydomResponse>(url: string): Promise<T[]> =>
+        await this.runWithFailover((client) => client.command<T>(url), `COMMAND ${url}`),
+      send: (rawHttpRequest: string): void => {
+        assert(this.activeClient, "Tydom client is not connected");
+        this.activeClient.send(rawHttpRequest);
+      },
+    } as TydomClient;
+  }
+  private getConnectionTargets(preferLocal: boolean): TydomConnectionTarget[] {
+    const { hostname, localHostname } = this.config;
+    const primaryTarget: TydomConnectionTarget = { hostname, type: "primary" };
+    if (!localHostname || localHostname === hostname) {
+      return [primaryTarget];
+    }
+    const localTarget: TydomConnectionTarget = { hostname: localHostname, type: "local" };
+    return preferLocal ? [localTarget, primaryTarget] : [primaryTarget, localTarget];
+  }
+  private createClientForTarget({ hostname, type }: TydomConnectionTarget): TydomClient {
+    const { username } = this.config;
+    this.log.info(
+      `Creating ${type} tydom client with username=${chalkString(username)} and hostname=${chalkString(
+        hostname,
+      )}`,
+    );
+    return createTydomClient({
+      username,
+      password: this.password,
+      hostname,
+      followUpDebounce: 500,
+      retryOnClose: false,
+    });
+  }
+  private async establishConnection(preferLocal: boolean): Promise<void> {
+    const wasConnected = this.hasConnectedOnce;
+    const target = await this.connectToFirstAvailableTarget(this.getConnectionTargets(preferLocal));
+    if (wasConnected) {
+      this.log.warn(`Reconnected to Tydom hostname=${chalkString(target.hostname)}, re-syncing state...`);
+      this.resync().catch((err: unknown) => {
+        this.log.error(`Failed to re-sync after reconnection: ${stringifyError(err as Error)}`);
+      });
+    } else {
+      this.hasConnectedOnce = true;
+    }
+    this.emit("connect");
+  }
+  private async connectToFirstAvailableTarget(
+    targets: TydomConnectionTarget[],
+  ): Promise<TydomConnectionTarget> {
+    let lastError: unknown;
+    for (const target of targets) {
+      debug(`Connecting to ${target.type} hostname=${chalkString(target.hostname)}...`);
+      try {
+        await this.connectToTarget(target);
+        return target;
+      } catch (err) {
+        lastError = err;
+        this.log.warn(
+          `Failed to connect to ${target.type} Tydom hostname=${chalkString(target.hostname)}: ${stringifyError(
+            err as Error,
+          )}`,
+        );
+      }
+    }
+    throw lastError instanceof Error ? lastError : new Error("Failed to connect to any Tydom hostname");
+  }
+  private async connectToTarget(target: TydomConnectionTarget): Promise<void> {
+    const client = this.createClientForTarget(target);
+    this.attachClientHandlers(client, target);
+    try {
+      await client.connect();
+      await asyncWait(250);
+      await client.get("/ping");
+      this.activateClient(client, target);
+    } catch (err) {
+      this.closeClient(client);
+      throw err;
+    }
+  }
+  private activateClient(client: TydomClient, target: TydomConnectionTarget): void {
+    const previousClient = this.activeClient;
+    this.activeClient = client;
+    this.activeHostname = target.hostname;
+    this.activeTargetType = target.type;
+    this.reconnectAttempt = 0;
+    this.clearReconnectTimeout();
+    if (target.type === "local") {
+      this.schedulePrimaryRetry();
+    } else {
+      this.clearPrimaryRetryTimeout();
+    }
+    if (previousClient && previousClient !== client) {
+      this.closeClient(previousClient);
+    }
+    this.log.info(
+      `Successfully connected to ${target.type} Tydom hostname=${chalkString(
+        target.hostname,
+      )} with username=${chalkString(this.config.username)}`,
+    );
+  }
+  private attachClientHandlers(client: TydomClient, target: TydomConnectionTarget): void {
+    client.on("message", (message: TydomHttpMessage) => {
+      try {
+        this.handleMessage(message);
+      } catch (err) {
+        this.log.error(
+          `Encountered an uncaught error=${stringifyError(err as Error)} while processing message=${chalkJson(message)}"`,
+        );
+      }
+    });
+    client.on("disconnect", () => {
+      if (this.closingClients.has(client) || this.activeClient !== client) {
+        return;
+      }
+      this.log.warn(`Disconnected from ${target.type} Tydom hostname=${chalkString(target.hostname)}`);
+      this.clearRefreshInterval();
+      this.emit("disconnect");
+      this.scheduleReconnect(target.type === "primary");
+    });
+  }
+  private clearRefreshInterval(): void {
+    if (this.refreshInterval) {
+      clearInterval(this.refreshInterval);
+      this.refreshInterval = undefined;
+    }
+  }
+  private clearReconnectTimeout(): void {
+    if (this.reconnectTimeout) {
+      clearTimeout(this.reconnectTimeout);
+      this.reconnectTimeout = undefined;
+    }
+  }
+  private clearPrimaryRetryTimeout(): void {
+    if (this.primaryRetryTimeout) {
+      clearTimeout(this.primaryRetryTimeout);
+      this.primaryRetryTimeout = undefined;
+    }
+  }
+  private closeClient(client: TydomClient): void {
+    this.closingClients.add(client);
+    client.close();
+  }
+  private async runWithFailover<T>(
+    operation: TydomClientOperation<T>,
+    operationName: string,
+    { retryOperation = true }: TydomFailoverOptions = {},
+  ): Promise<T> {
+    assert(this.activeClient, "Tydom client is not connected");
+    try {
+      return await operation(this.activeClient);
+    } catch (err) {
+      if (!this.shouldTryLocalFallback()) {
+        throw err;
+      }
+      this.log.warn(
+        `Tydom ${operationName} failed on hostname=${chalkString(
+          this.activeHostname ?? "unknown",
+        )}, trying local fallback hostname=${chalkString(this.config.localHostname ?? "unknown")}: ${stringifyError(
+          err as Error,
+        )}`,
+      );
+      await this.failoverToLocal();
+      const shouldRetryOperation = typeof retryOperation === "function" ? retryOperation(err) : retryOperation;
+      if (!shouldRetryOperation) {
+        throw err;
+      }
+      assert(this.activeClient, "Tydom client is not connected");
+      return await operation(this.activeClient);
+    }
+  }
+  private canRetryMutationAfterFailover(err: unknown): boolean {
+    const message = err instanceof Error ? err.message : String(err);
+    return (
+      message.includes("Required socket instance") || message.includes("Socket instance is closing/closed")
+    );
+  }
+  private shouldTryLocalFallback(): boolean {
+    const { localHostname } = this.config;
+    return Boolean(localHostname && this.activeHostname !== localHostname);
+  }
+  private async failoverToLocal(): Promise<void> {
+    this.failoverPromise ??= this.establishConnection(true).finally(() => {
+      this.failoverPromise = undefined;
+    });
+    await this.failoverPromise;
+  }
+  private getPrimaryRetryIntervalMs(): number {
+    const { primaryRetryInterval = DEFAULT_PRIMARY_RETRY_INTERVAL_SEC } = this.config;
+    return Math.max(30, primaryRetryInterval) * 1000;
+  }
+  private schedulePrimaryRetry(): void {
+    const { hostname, localHostname } = this.config;
+    if (!localHostname || localHostname === hostname || this.activeTargetType !== "local") {
+      return;
+    }
+    this.clearPrimaryRetryTimeout();
+    const retryIntervalMs = this.getPrimaryRetryIntervalMs();
+    debug(
+      `Scheduling primary Tydom retry for hostname=${chalkString(hostname)} in ${chalkNumber(
+        Math.round(retryIntervalMs / 1000),
+      )}s while using local fallback`,
+    );
+    this.primaryRetryTimeout = setTimeout(() => {
+      this.tryRestorePrimaryConnection().catch((err: unknown) => {
+        this.log.warn(
+          `Failed to restore primary Tydom hostname=${chalkString(hostname)}: ${stringifyError(err as Error)}`,
+        );
+        this.schedulePrimaryRetry();
+      });
+    }, retryIntervalMs);
+  }
+  private async tryRestorePrimaryConnection(): Promise<void> {
+    const { hostname } = this.config;
+    if (this.activeTargetType !== "local") {
+      return;
+    }
+    this.log.info(`Checking if primary Tydom hostname=${chalkString(hostname)} is available again...`);
+    await this.connectToTarget({ hostname, type: "primary" });
+    this.log.warn(
+      `Restored primary Tydom hostname=${chalkString(hostname)}, switching back from local fallback`,
+    );
+    this.resync().catch((err: unknown) => {
+      this.log.error(`Failed to re-sync after primary restoration: ${stringifyError(err as Error)}`);
+    });
+    this.emit("connect");
+  }
+  private scheduleReconnect(preferLocal: boolean): void {
+    this.clearReconnectTimeout();
+    this.reconnectAttempt += 1;
+    const delay = Math.min(
+      RECONNECT_BASE_DELAY_MS * Math.pow(2, this.reconnectAttempt - 1),
+      MAX_RECONNECT_DELAY_MS,
+    );
+    this.log.warn(`Reconnecting to Tydom in ${Math.round(delay / 1000)}s...`);
+    this.reconnectTimeout = setTimeout(() => {
+      this.establishConnection(preferLocal).catch((err: unknown) => {
+        this.log.error(`Failed to reconnect to Tydom: ${stringifyError(err as Error)}`);
+        this.scheduleReconnect(preferLocal);
+      });
+    }, delay);
+  }
   private async resync(): Promise<void> {
     const { hostname, refreshInterval = DEFAULT_REFRESH_INTERVAL_SEC } = this.config;
     debug(`Re-syncing state after reconnection to hostname=${chalkString(hostname)}...`);
@@ -248,7 +511,7 @@ export default class TydomController extends EventEmitter {
       try {
         await this.refresh();
       } catch (err) {
-        debug(`Failed interval refresh with err ${err}`);
+        debug(`Failed interval refresh with err ${stringifyError(err as Error)}`);
       }
     }, refreshInterval * 1000);
   }

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from "node:events";
 import type { Logging } from "homebridge";
 import type { Categories } from "homebridge";
 import { createTranslator, type Translator } from "./i18n/index.js";
+import type { TydomTransport } from "./api/client.js";
 import { discoverDevices, expandCompanions } from "./api/discovery.js";
 import {
   classifyMessage,
@@ -42,6 +43,7 @@ import type TydomClient from "tydom-client";
 import {
   createClient as createTydomClient,
   type TydomHttpMessage,
+  type TydomRequestBody,
   type TydomResponse,
 } from "tydom-client";
 
@@ -54,10 +56,37 @@ export type ControllerUpdatePayload = {
   context: TydomAccessoryContext;
 };
 
+type ConnectionTarget = {
+  hostname: string;
+  type: "primary" | "local";
+};
+
+type TransportRetry = "safe" | "only-if-unsent";
+
+export type TydomControllerOptions = {
+  clientFactory?: typeof createTydomClient;
+  gatewayPasswordResolver?: typeof resolveGatewayPassword;
+};
+
+const RECONNECT_BASE_DELAY_MS = 5_000;
+const MAX_RECONNECT_DELAY_MS = 5 * 60_000;
+
 export default class TydomController extends EventEmitter {
   public client: TydomClient;
+  public readonly transport: TydomTransport;
   public config: TydomPlatformConfig;
   public log: Logging;
+  private readonly clientFactory: typeof createTydomClient;
+  private readonly gatewayPasswordResolver: typeof resolveGatewayPassword;
+  private readonly managedFallback: boolean;
+  private activeTarget: ConnectionTarget;
+  private transitionPromise: Promise<void> | undefined;
+  private transitionClient: TydomClient | undefined;
+  private initialClientAvailable = true;
+  private reconnectTimeout: NodeJS.Timeout | undefined;
+  private primaryRetryTimeout: NodeJS.Timeout | undefined;
+  private primaryProbeClient: TydomClient | undefined;
+  private reconnectAttempt = 0;
   /**
    * Known endpoints, by `deviceId:endpointId`.
    *
@@ -111,22 +140,44 @@ export default class TydomController extends EventEmitter {
   private gatewayPassword: string;
   /** Delta Dore label lookups, bound to the configured locale. */
   private readonly t: Translator;
-  constructor(log: Logging, config: TydomPlatformConfig) {
+  constructor(log: Logging, config: TydomPlatformConfig, options: TydomControllerOptions = {}) {
     super();
     this.config = config;
     this.log = log;
+    this.clientFactory = options.clientFactory ?? createTydomClient;
+    this.gatewayPasswordResolver = options.gatewayPasswordResolver ?? resolveGatewayPassword;
+    this.managedFallback = Boolean(config.localHostname);
     this.t = createTranslator(config.locale);
     // hostname/username/password are validated and resolved by parseConfig,
     // so there is nothing left to assert here.
-    const { hostname, username, password, email } = config;
-    this.log.info(
-      `Creating tydom client with username=${styleString(username)} and hostname=${styleString(hostname)}`,
-    );
+    const { hostname, password, email } = config;
     // With an e-mail configured, `password` belongs to the account rather than
     // the gateway, so the client starts out with no usable credential and
     // `connect` fills one in.
     this.gatewayPassword = email ? "" : password;
-    this.client = this.createClient(this.gatewayPassword);
+    this.activeTarget = { hostname, type: "primary" };
+    this.client = this.createClientForTarget(this.activeTarget);
+    this.transport = {
+      get: async (uri) => await this.runTransport((client) => client.get(uri), "safe"),
+      put: async (uri, body) =>
+        await this.runTransport(
+          (client) => client.put(uri, body as TydomRequestBody | undefined),
+          "only-if-unsent",
+        ),
+      post: async (uri, body) =>
+        await this.runTransport(
+          (client) => client.post(uri, body as TydomRequestBody | undefined),
+          "only-if-unsent",
+        ),
+      command: async (uri) => await this.runTransport((client) => client.command(uri), "safe"),
+    };
+    if (config.localHostname && process.env["NODE_TLS_REJECT_UNAUTHORIZED"] !== "0") {
+      this.log.warn(
+        `Local Tydom fallback hostname=${styleString(
+          config.localHostname,
+        )} is configured but NODE_TLS_REJECT_UNAUTHORIZED is not set to 0; its self-signed certificate may be rejected`,
+      );
+    }
   }
   /**
    * Build a client for `password` and wire its events up.
@@ -135,10 +186,26 @@ export default class TydomController extends EventEmitter {
    * arrive once `connect` has been able to await the account API, and the
    * client takes its password at construction time.
    */
-  private createClient(password: string): TydomClient {
-    const { hostname, username } = this.config;
-    const client = createTydomClient({ username, password, hostname, followUpDebounce: 500 });
+  private createClientForTarget(target: ConnectionTarget): TydomClient {
+    const { username } = this.config;
+    this.log.info(
+      `Creating ${target.type} tydom client with username=${styleString(username)} and hostname=${styleString(
+        target.hostname,
+      )}`,
+    );
+    const client = this.clientFactory({
+      username,
+      password: this.gatewayPassword,
+      hostname: target.hostname,
+      followUpDebounce: 500,
+      // A client which may be abandoned for another hostname must not keep an
+      // inaccessible reconnect timer alive behind the controller's back.
+      retryOnClose: !this.managedFallback,
+    });
     client.on("message", (message: TydomHttpMessage) => {
+      if (this.disposed || client !== this.client) {
+        return;
+      }
       try {
         this.handleMessage(message);
       } catch (err) {
@@ -148,16 +215,18 @@ export default class TydomController extends EventEmitter {
       }
     });
     client.on("connect", () => {
-      if (this.disposed) {
+      // Managed clients are activated only after their explicit /ping succeeds.
+      // Their socket emits `connect` before that handshake has completed.
+      if (this.disposed || this.managedFallback || client !== this.client) {
         return;
       }
       this.connected = true;
       this.log.info(
-        `Successfully connected to Tydom hostname=${styleString(hostname)} with username=${styleString(username)}`,
+        `Successfully connected to Tydom hostname=${styleString(target.hostname)} with username=${styleString(username)}`,
       );
       if (this.hasConnectedOnce) {
         this.log.warn(
-          `Reconnected to Tydom hostname=${styleString(hostname)}, re-syncing state...`,
+          `Reconnected to Tydom hostname=${styleString(target.hostname)}, re-syncing state...`,
         );
         this.resync().catch((err: unknown) => {
           this.log.error(`Failed to re-sync after reconnection: ${stringifyError(err as Error)}`);
@@ -166,16 +235,20 @@ export default class TydomController extends EventEmitter {
       this.emit("connect");
     });
     client.on("disconnect", () => {
+      if (client !== this.client) {
+        return;
+      }
       this.connected = false;
       if (this.disposed) {
         return;
       }
-      this.log.warn(`Disconnected from Tydom hostname=${styleString(hostname)}`);
-      if (this.refreshInterval) {
-        clearInterval(this.refreshInterval);
-        this.refreshInterval = undefined;
-      }
+      this.log.warn(`Disconnected from Tydom hostname=${styleString(target.hostname)}`);
+      this.clearRefreshInterval();
+      this.clearPrimaryRetryTimeout();
       this.emit("disconnect");
+      if (this.managedFallback) {
+        this.scheduleReconnect();
+      }
     });
     return client;
   }
@@ -195,7 +268,7 @@ export default class TydomController extends EventEmitter {
     this.log.info(
       `Resolving the gateway password from the Delta Dore account of ${styleString(maskEmail(email))}...`,
     );
-    const password = await resolveGatewayPassword({
+    const password = await this.gatewayPasswordResolver({
       email,
       password: accountPassword,
       mac: username,
@@ -204,8 +277,10 @@ export default class TydomController extends EventEmitter {
     // The client takes its password at construction, so the placeholder built
     // in the constructor has to be replaced rather than reconfigured. Nothing
     // has connected yet, so there is no socket to migrate — only listeners.
-    this.client.removeAllListeners();
-    this.client = this.createClient(password);
+    this.retireClient(this.client);
+    this.activeTarget = { hostname: this.config.hostname, type: "primary" };
+    this.client = this.createClientForTarget(this.activeTarget);
+    this.initialClientAvailable = true;
     this.log.info(`Resolved the gateway password for username=${styleString(username)}`);
   }
   /** Whether a socket is up, however it got there. */
@@ -222,6 +297,10 @@ export default class TydomController extends EventEmitter {
     // `DeltaDoreAuthError` and stops rather than retrying it.
     await this.resolveGatewayPassword();
     try {
+      if (this.managedFallback) {
+        await this.startManagedTransition(false);
+        return;
+      }
       await this.client.connect();
       await asyncWait(250);
       // Initial intro handshake
@@ -234,30 +313,321 @@ export default class TydomController extends EventEmitter {
       throw err;
     }
   }
+
+  private get currentHostname(): string {
+    return this.activeTarget.hostname;
+  }
+
+  private connectionTargets(preferLocal: boolean): ConnectionTarget[] {
+    const primary: ConnectionTarget = { hostname: this.config.hostname, type: "primary" };
+    const localHostname = this.config.localHostname;
+    if (!localHostname) {
+      return [primary];
+    }
+    const local: ConnectionTarget = { hostname: localHostname, type: "local" };
+    return preferLocal ? [local, primary] : [primary, local];
+  }
+
+  /**
+   * Run one hostname transition at a time.
+   *
+   * The ordinary, single-host setup never reaches this path and keeps
+   * tydom-client's automatic reconnect behaviour unchanged. With a fallback,
+   * the controller is the sole retry owner so a retired primary cannot open a
+   * second socket after the local client has taken over.
+   */
+  private async startManagedTransition(preferLocal: boolean): Promise<void> {
+    if (this.disposed) {
+      throw new Error("Tydom controller is disposed");
+    }
+    if (this.transitionPromise) {
+      return this.transitionPromise;
+    }
+    this.clearReconnectTimeout();
+    const run = this.connectToFirstAvailableTarget(this.connectionTargets(preferLocal));
+    this.transitionPromise = run;
+    try {
+      await run;
+    } finally {
+      if (this.transitionPromise === run) {
+        this.transitionPromise = undefined;
+      }
+    }
+  }
+
+  private async connectToFirstAvailableTarget(targets: ConnectionTarget[]): Promise<void> {
+    let lastError: unknown;
+    for (const target of targets) {
+      try {
+        await this.connectToTarget(target);
+        return;
+      } catch (err) {
+        lastError = err;
+        this.log.warn(
+          `Failed to connect to ${target.type} Tydom hostname=${styleString(target.hostname)}: ${stringifyError(
+            err as Error,
+          )}`,
+        );
+      }
+    }
+    throw lastError instanceof Error
+      ? lastError
+      : new Error("Failed to connect to any Tydom hostname");
+  }
+
+  private async connectToTarget(target: ConnectionTarget): Promise<void> {
+    debug(`Connecting to ${target.type} hostname=${styleString(target.hostname)}...`);
+    const canUseInitialClient =
+      this.initialClientAvailable &&
+      target.type === this.activeTarget.type &&
+      target.hostname === this.activeTarget.hostname;
+    const candidate = canUseInitialClient ? this.client : this.createClientForTarget(target);
+    this.initialClientAvailable = false;
+    this.transitionClient = candidate;
+    try {
+      await candidate.connect();
+      await asyncWait(250);
+      await candidate.get("/ping");
+      if (this.disposed) {
+        throw new Error("Tydom controller was disposed while connecting");
+      }
+      this.activateManagedClient(candidate, target);
+    } catch (err) {
+      this.retireClient(candidate);
+      throw err;
+    } finally {
+      if (this.transitionClient === candidate) {
+        this.transitionClient = undefined;
+      }
+    }
+  }
+
+  private activateManagedClient(client: TydomClient, target: ConnectionTarget): void {
+    const previousClient = this.client;
+    const reconnecting = this.hasConnectedOnce;
+    this.client = client;
+    this.activeTarget = target;
+    this.connected = true;
+    this.hasConnectedOnce = true;
+    this.reconnectAttempt = 0;
+    this.clearReconnectTimeout();
+    if (target.type === "local") {
+      this.schedulePrimaryRetry();
+    } else {
+      this.clearPrimaryRetryTimeout();
+    }
+    if (previousClient !== client) {
+      this.retireClient(previousClient);
+    }
+    this.log.info(
+      `Successfully connected to ${target.type} Tydom hostname=${styleString(
+        target.hostname,
+      )} with username=${styleString(this.config.username)}`,
+    );
+    if (reconnecting) {
+      this.log.warn(
+        `Reconnected to Tydom hostname=${styleString(target.hostname)}, re-syncing state...`,
+      );
+      void this.resync().catch((err: unknown) => {
+        this.log.error(`Failed to re-sync after reconnection: ${stringifyError(err as Error)}`);
+      });
+    }
+    this.emit("connect");
+  }
+
+  private async runTransport<T>(
+    operation: (client: TydomClient) => Promise<T>,
+    retry: TransportRetry,
+  ): Promise<T> {
+    if (this.managedFallback && (!this.connected || this.transitionPromise)) {
+      await this.startManagedTransition(true);
+    }
+    const client = this.client;
+    try {
+      return await operation(client);
+    } catch (err) {
+      if (!this.managedFallback) {
+        throw err;
+      }
+
+      // The request may have started just before another caller completed the
+      // transition. Reads can move to the new socket; ambiguous writes cannot.
+      if (client !== this.client) {
+        if (retry === "safe" || (retry === "only-if-unsent" && this.wasDefinitelyNotSent(err))) {
+          return await operation(this.client);
+        }
+        throw err;
+      }
+
+      if (this.connected && !this.isTransportFailure(err)) {
+        throw err;
+      }
+      this.connected = false;
+      this.clearRefreshInterval();
+      try {
+        await this.startManagedTransition(true);
+      } catch {
+        this.scheduleReconnect();
+        throw err;
+      }
+      if (retry === "safe" || (retry === "only-if-unsent" && this.wasDefinitelyNotSent(err))) {
+        return await operation(this.client);
+      }
+      throw err;
+    }
+  }
+
+  private isTransportFailure(err: unknown): boolean {
+    const message = err instanceof Error ? err.message : String(err);
+    return /Required socket instance|Socket instance is closing\/closed|Socket closed while request was pending|Request timed out|ECONN|ENOTFOUND|EAI_AGAIN|ETIMEDOUT|fetch failed/i.test(
+      message,
+    );
+  }
+
+  /** Errors raised before `socket.send`, for which replay cannot duplicate an action. */
+  private wasDefinitelyNotSent(err: unknown): boolean {
+    const message = err instanceof Error ? err.message : String(err);
+    return /Required socket instance|Socket instance is closing\/closed/i.test(message);
+  }
+
+  private scheduleReconnect(): void {
+    if (this.disposed || !this.managedFallback || this.connected || this.transitionPromise) {
+      return;
+    }
+    this.clearReconnectTimeout();
+    this.reconnectAttempt += 1;
+    const delay = Math.min(
+      RECONNECT_BASE_DELAY_MS * 2 ** (this.reconnectAttempt - 1),
+      MAX_RECONNECT_DELAY_MS,
+    );
+    this.log.warn(`Reconnecting to Tydom in ${Math.round(delay / 1000)}s...`);
+    this.reconnectTimeout = setTimeout(() => {
+      this.reconnectTimeout = undefined;
+      void this.startManagedTransition(true).catch((err: unknown) => {
+        this.log.error(`Failed to reconnect to Tydom: ${stringifyError(err as Error)}`);
+        this.scheduleReconnect();
+      });
+    }, delay);
+    this.reconnectTimeout.unref?.();
+  }
+
+  private schedulePrimaryRetry(): void {
+    if (
+      this.disposed ||
+      !this.connected ||
+      this.activeTarget.type !== "local" ||
+      this.primaryProbeClient
+    ) {
+      return;
+    }
+    this.clearPrimaryRetryTimeout();
+    this.primaryRetryTimeout = setTimeout(() => {
+      this.primaryRetryTimeout = undefined;
+      void this.tryRestorePrimary().catch((err: unknown) => {
+        this.log.warn(
+          `Failed to restore primary Tydom hostname=${styleString(
+            this.config.hostname,
+          )}: ${stringifyError(err as Error)}`,
+        );
+        this.schedulePrimaryRetry();
+      });
+    }, this.config.primaryRetryIntervalMs);
+    this.primaryRetryTimeout.unref?.();
+  }
+
+  private async tryRestorePrimary(): Promise<void> {
+    if (this.disposed || !this.connected || this.activeTarget.type !== "local") {
+      return;
+    }
+    const localClient = this.client;
+    const target: ConnectionTarget = { hostname: this.config.hostname, type: "primary" };
+    const candidate = this.createClientForTarget(target);
+    this.primaryProbeClient = candidate;
+    let activated = false;
+    try {
+      this.log.info(
+        `Checking if primary Tydom hostname=${styleString(target.hostname)} is available again...`,
+      );
+      await candidate.connect();
+      await asyncWait(250);
+      await candidate.get("/ping");
+      if (
+        this.disposed ||
+        !this.connected ||
+        this.client !== localClient ||
+        this.activeTarget.type !== "local"
+      ) {
+        return;
+      }
+      activated = true;
+      this.primaryProbeClient = undefined;
+      this.activateManagedClient(candidate, target);
+      this.log.warn(
+        `Restored primary Tydom hostname=${styleString(target.hostname)}, switching back from local fallback`,
+      );
+    } finally {
+      if (this.primaryProbeClient === candidate) {
+        this.primaryProbeClient = undefined;
+      }
+      if (!activated) {
+        this.retireClient(candidate);
+      }
+    }
+  }
+
+  private clearRefreshInterval(): void {
+    if (this.refreshInterval) {
+      clearInterval(this.refreshInterval);
+      this.refreshInterval = undefined;
+    }
+  }
+
+  private clearReconnectTimeout(): void {
+    if (this.reconnectTimeout) {
+      clearTimeout(this.reconnectTimeout);
+      this.reconnectTimeout = undefined;
+    }
+  }
+
+  private clearPrimaryRetryTimeout(): void {
+    if (this.primaryRetryTimeout) {
+      clearTimeout(this.primaryRetryTimeout);
+      this.primaryRetryTimeout = undefined;
+    }
+  }
+
+  private retireClient(client: TydomClient): void {
+    try {
+      client.removeAllListeners();
+      client.close();
+    } catch (err) {
+      debug(`Ignoring error while closing a Tydom client: ${String(err)}`);
+    }
+  }
+
   async sync(): Promise<{
     config: TydomConfigResponse;
     groups: TydomGroupsResponse;
     meta: TydomMetaResponse;
   }> {
-    const { hostname } = this.config;
-    debug(`Syncing state from hostname=${styleString(hostname)}...`);
+    debug(`Syncing state from hostname=${styleString(this.currentHostname)}...`);
     // Checked rather than cast: everything downstream assumes these shapes, and
     // an unnoticed change here would surface as a TypeError deep inside
     // discovery instead of naming the endpoint that actually moved.
     const config = parseDiscoveryResponse(
       "/configs/file",
       tydomConfigResponseSchema,
-      await this.client.get("/configs/file"),
+      await this.transport.get("/configs/file"),
     );
     const groups = parseDiscoveryResponse(
       "/groups/file",
       tydomGroupsResponseSchema,
-      await this.client.get("/groups/file"),
+      await this.transport.get("/groups/file"),
     );
     const meta = parseDiscoveryResponse(
       "/devices/meta",
       tydomMetaResponseSchema,
-      await this.client.get("/devices/meta"),
+      await this.transport.get("/devices/meta"),
     );
     // Final outro handshake
     await this.refresh();
@@ -265,8 +635,8 @@ export default class TydomController extends EventEmitter {
     return { config, groups, meta };
   }
   async scan(): Promise<void> {
-    const { hostname, username, settings = {} } = this.config;
-    this.log.info(`Scanning devices from hostname=${styleString(hostname)}...`);
+    const { username, settings = {} } = this.config;
+    this.log.info(`Scanning devices from hostname=${styleString(this.currentHostname)}...`);
     const { config, groups, meta } = await this.sync();
 
     const { devices, skipped } = discoverDevices({
@@ -335,7 +705,7 @@ export default class TydomController extends EventEmitter {
   }
   async refresh(): Promise<void> {
     debug(`Refreshing Tydom controller ...`);
-    await this.client.post("/refresh/all");
+    await this.transport.post("/refresh/all");
   }
   /**
    * (Re-)install the periodic full refresh.
@@ -390,13 +760,14 @@ export default class TydomController extends EventEmitter {
   }
 
   private async runResync(): Promise<void> {
-    const { hostname } = this.config;
-    debug(`Re-syncing state after reconnection to hostname=${styleString(hostname)}...`);
+    debug(
+      `Re-syncing state after reconnection to hostname=${styleString(this.currentHostname)}...`,
+    );
     await asyncWait(250);
     if (this.disposed) {
       return;
     }
-    await this.client.get("/ping");
+    await this.transport.get("/ping");
     await this.refresh();
     if (this.disposed) {
       return;
@@ -415,16 +786,19 @@ export default class TydomController extends EventEmitter {
    */
   dispose(): void {
     this.disposed = true;
-    if (this.refreshInterval) {
-      clearInterval(this.refreshInterval);
-      this.refreshInterval = undefined;
+    this.connected = false;
+    this.clearRefreshInterval();
+    this.clearReconnectTimeout();
+    this.clearPrimaryRetryTimeout();
+    if (this.primaryProbeClient) {
+      this.retireClient(this.primaryProbeClient);
+      this.primaryProbeClient = undefined;
     }
-    try {
-      this.client.removeAllListeners();
-      this.client.close();
-    } catch (err) {
-      debug(`Ignoring error while closing the Tydom client: ${String(err)}`);
+    if (this.transitionClient && this.transitionClient !== this.client) {
+      this.retireClient(this.transitionClient);
+      this.transitionClient = undefined;
     }
+    this.retireClient(this.client);
   }
 
   handleMessage(message: TydomHttpMessage): void {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -20,9 +20,10 @@ import { stringifyError } from "src/utils/error";
 
 export type TydomPlatformConfig = PlatformConfig & {
   hostname: string;
+  localHostname?: string;
   username: string;
   password: string;
-  settings: Record<string, { name?: string; category?: Categories }>;
+  settings?: Record<string, { name?: string; category?: Categories } | undefined>;
   debug?: boolean;
   webhooks?: Webhook[];
   includedDevices?: string[];
@@ -30,6 +31,7 @@ export type TydomPlatformConfig = PlatformConfig & {
   excludedDevices?: string[];
   excludedCategories?: string[];
   refreshInterval?: number;
+  primaryRetryInterval?: number;
 };
 
 export default class TydomPlatform implements DynamicPlatformPlugin {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -123,12 +123,7 @@ export default class TydomPlatform implements DynamicPlatformPlugin {
       //
       // tydom-client's methods are generic over the response type; the
       // transport seam deliberately is not, so it can be faked in tests.
-      transport: {
-        get: (uri) => controller.client.get(uri),
-        put: (uri, body) => controller.client.put(uri, body as never),
-        post: (uri, body) => controller.client.post(uri, body as never),
-        command: (uri) => controller.client.command(uri),
-      } satisfies TydomTransport,
+      transport: controller.transport satisfies TydomTransport,
       logger: this.pluginLog,
     });
     this.api.on("didFinishLaunching", () => {

--- a/test/config.spec.ts
+++ b/test/config.spec.ts
@@ -2,8 +2,10 @@ import type { PlatformConfig } from "homebridge";
 import { describe, expect, it } from "vitest";
 import {
   ConfigError,
+  DEFAULT_PRIMARY_RETRY_INTERVAL_MS,
   DEFAULT_REFRESH_INTERVAL_MS,
   DEFAULT_STALE_AFTER_MS,
+  MIN_PRIMARY_RETRY_INTERVAL_MS,
   MIN_REFRESH_INTERVAL_MS,
   parseConfig,
 } from "../src/config.js";
@@ -22,11 +24,13 @@ describe("parseConfig", () => {
   it("parses a minimal config", () => {
     const config = parseConfig(base, {});
     expect(config.hostname).toBe("mediation.tydom.com");
+    expect(config.localHostname).toBeUndefined();
     expect(config.username).toBe("001A25123456");
     expect(config.password).toBe("s3cret");
     expect(config.debug).toBe(false);
     expect(config.locale).toBe("fr");
     expect(config.refreshIntervalMs).toBe(DEFAULT_REFRESH_INTERVAL_MS);
+    expect(config.primaryRetryIntervalMs).toBe(DEFAULT_PRIMARY_RETRY_INTERVAL_MS);
   });
 
   it("trims whitespace out of the hostname and username", () => {
@@ -154,6 +158,32 @@ describe("parseConfig", () => {
       expect(parseConfig({ ...base, refreshInterval: "soon" } as never, {}).refreshIntervalMs).toBe(
         DEFAULT_REFRESH_INTERVAL_MS,
       );
+    });
+  });
+
+  describe("local fallback", () => {
+    it("trims and keeps a distinct local hostname", () => {
+      const config = parseConfig(
+        { ...base, localHostname: "  192.168.1.42  ", primaryRetryInterval: 45 } as never,
+        {},
+      );
+      expect(config.localHostname).toBe("192.168.1.42");
+      expect(config.primaryRetryIntervalMs).toBe(45_000);
+    });
+
+    it("disables a fallback that names the primary endpoint", () => {
+      const config = parseConfig({ ...base, localHostname: " mediation.tydom.com " } as never, {});
+      expect(config.localHostname).toBeUndefined();
+    });
+
+    it("clamps an aggressive primary retry interval", () => {
+      const config = parseConfig({ ...base, primaryRetryInterval: 1 } as never, {});
+      expect(config.primaryRetryIntervalMs).toBe(MIN_PRIMARY_RETRY_INTERVAL_MS);
+    });
+
+    it("uses the default for a non-numeric primary retry interval", () => {
+      const config = parseConfig({ ...base, primaryRetryInterval: "soon" } as never, {});
+      expect(config.primaryRetryIntervalMs).toBe(DEFAULT_PRIMARY_RETRY_INTERVAL_MS);
     });
   });
 

--- a/test/fallback.spec.ts
+++ b/test/fallback.spec.ts
@@ -1,0 +1,423 @@
+import { EventEmitter } from "node:events";
+import type { Logging, PlatformConfig } from "homebridge";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { parseConfig } from "../src/config.js";
+import TydomController, { type TydomControllerOptions } from "../src/controller.js";
+
+type ClientOptions = {
+  hostname?: string;
+  password: string;
+  retryOnClose?: boolean;
+};
+
+type Call = {
+  hostname: string;
+  operation: string;
+  retryOnClose?: boolean | undefined;
+  password?: string | undefined;
+};
+
+const deferred = (): { promise: Promise<void>; resolve: () => void } => {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+};
+
+class ClientHarness {
+  readonly calls: Call[] = [];
+  readonly clients: FakeClient[] = [];
+  readonly failures = new Map<string, Error[]>();
+  readonly connectGates = new Map<string, Promise<void>[]>();
+
+  readonly factory = ((options: ClientOptions) => {
+    const client = new FakeClient(this, options);
+    this.clients.push(client);
+    this.calls.push({
+      hostname: client.hostname,
+      operation: "create",
+      retryOnClose: options.retryOnClose,
+      password: options.password,
+    });
+    return client;
+  }) as unknown as NonNullable<TydomControllerOptions["clientFactory"]>;
+
+  fail(hostname: string, operation: string, ...errors: Error[]): void {
+    this.failures.set(`${hostname} ${operation}`, errors);
+  }
+
+  takeFailure(hostname: string, operation: string): Error | undefined {
+    const key = `${hostname} ${operation}`;
+    const failures = this.failures.get(key);
+    const failure = failures?.shift();
+    if (failures?.length === 0) {
+      this.failures.delete(key);
+    }
+    return failure;
+  }
+
+  deferConnect(hostname: string): () => void {
+    const { promise: gate, resolve: release } = deferred();
+    const gates = this.connectGates.get(hostname) ?? [];
+    gates.push(gate);
+    this.connectGates.set(hostname, gates);
+    return release;
+  }
+
+  takeConnectGate(hostname: string): Promise<void> | undefined {
+    const gates = this.connectGates.get(hostname);
+    const gate = gates?.shift();
+    if (gates?.length === 0) {
+      this.connectGates.delete(hostname);
+    }
+    return gate;
+  }
+
+  count(hostname: string, operation: string): number {
+    return this.calls.filter((call) => call.hostname === hostname && call.operation === operation)
+      .length;
+  }
+}
+
+class FakeClient extends EventEmitter {
+  readonly hostname: string;
+
+  constructor(
+    private readonly harness: ClientHarness,
+    options: ClientOptions,
+  ) {
+    super();
+    this.hostname = options.hostname ?? "mediation.tydom.com";
+  }
+
+  async connect(): Promise<unknown> {
+    this.record("connect");
+    this.throwFailure("connect");
+    await this.harness.takeConnectGate(this.hostname);
+    this.emit("connect");
+    return {};
+  }
+
+  async get(uri: string): Promise<Record<string, unknown>> {
+    this.record(`get ${uri}`);
+    this.throwFailure(`get ${uri}`);
+    return {};
+  }
+
+  async put(uri: string): Promise<Record<string, unknown>> {
+    this.record(`put ${uri}`);
+    this.throwFailure(`put ${uri}`);
+    return {};
+  }
+
+  async post(uri: string): Promise<Record<string, unknown>> {
+    this.record(`post ${uri}`);
+    this.throwFailure(`post ${uri}`);
+    return {};
+  }
+
+  async command(uri: string): Promise<Record<string, unknown>[]> {
+    this.record(`command ${uri}`);
+    this.throwFailure(`command ${uri}`);
+    return [];
+  }
+
+  close(): void {
+    this.record("close");
+  }
+
+  private record(operation: string): void {
+    this.harness.calls.push({ hostname: this.hostname, operation });
+  }
+
+  private throwFailure(operation: string): void {
+    const failure = this.harness.takeFailure(this.hostname, operation);
+    if (failure) {
+      throw failure;
+    }
+  }
+}
+
+const PRIMARY = "mediation.tydom.com";
+const LOCAL = "192.168.1.42";
+
+const rawConfig = {
+  platform: "Tydom",
+  hostname: PRIMARY,
+  localHostname: LOCAL,
+  primaryRetryInterval: 30,
+  username: "001A25123456",
+  password: "s3cret",
+} as unknown as PlatformConfig;
+
+const createLog = (): Logging => {
+  const log = (() => {}) as unknown as Logging;
+  log.info = () => {};
+  log.warn = () => {};
+  log.error = () => {};
+  log.debug = () => {};
+  log.success = () => {};
+  return log;
+};
+
+const createController = (
+  harness = new ClientHarness(),
+  config: PlatformConfig = rawConfig,
+  options: Omit<TydomControllerOptions, "clientFactory"> = {},
+) => ({
+  harness,
+  controller: new TydomController(createLog(), parseConfig(config, {}), {
+    ...options,
+    clientFactory: harness.factory,
+  }),
+});
+
+const connect = async (controller: TydomController): Promise<void> => {
+  const connecting = controller.connect();
+  await vi.advanceTimersByTimeAsync(1_000);
+  await connecting;
+};
+
+describe("local fallback", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("leaves tydom-client automatic reconnection enabled without a fallback", () => {
+    const harness = new ClientHarness();
+    const config = { ...rawConfig, localHostname: undefined } as unknown as PlatformConfig;
+    const { controller } = createController(harness, config);
+    expect(harness.calls[0]).toMatchObject({
+      hostname: PRIMARY,
+      operation: "create",
+      retryOnClose: true,
+    });
+    controller.dispose();
+  });
+
+  it("uses only the primary endpoint when it is available", async () => {
+    const { controller, harness } = createController();
+    await connect(controller);
+    expect(controller.isConnected).toBe(true);
+    expect((controller.client as unknown as FakeClient).hostname).toBe(PRIMARY);
+    expect(harness.count(LOCAL, "connect")).toBe(0);
+    expect(harness.calls.filter((call) => call.operation === "create")).toSatisfy((calls: Call[]) =>
+      calls.every((call) => call.retryOnClose === false),
+    );
+    controller.dispose();
+  });
+
+  it("falls back locally during startup when the primary is unavailable", async () => {
+    const harness = new ClientHarness();
+    harness.fail(PRIMARY, "connect", new Error("ECONNREFUSED"));
+    const { controller } = createController(harness);
+    await connect(controller);
+    expect((controller.client as unknown as FakeClient).hostname).toBe(LOCAL);
+    expect(harness.count(PRIMARY, "connect")).toBe(1);
+    expect(harness.count(LOCAL, "connect")).toBe(1);
+    controller.dispose();
+  });
+
+  it("lets the platform own startup retries when both endpoints are unavailable", async () => {
+    const harness = new ClientHarness();
+    harness.fail(PRIMARY, "connect", new Error("ECONNREFUSED"));
+    harness.fail(LOCAL, "connect", new Error("ECONNREFUSED"));
+    const { controller } = createController(harness);
+    const connecting = controller.connect();
+    const outcome = connecting.then(
+      () => undefined,
+      (err: unknown) => err,
+    );
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(await outcome).toEqual(expect.objectContaining({ message: "ECONNREFUSED" }));
+    await vi.advanceTimersByTimeAsync(10 * 60_000);
+    expect(harness.count(PRIMARY, "connect")).toBe(1);
+    expect(harness.count(LOCAL, "connect")).toBe(1);
+    controller.dispose();
+  });
+
+  it("switches to local after the active primary disconnects", async () => {
+    const { controller, harness } = createController();
+    await connect(controller);
+    (controller.client as unknown as FakeClient).emit("disconnect");
+    await vi.advanceTimersByTimeAsync(6_000);
+    expect((controller.client as unknown as FakeClient).hostname).toBe(LOCAL);
+    expect(harness.count(LOCAL, "connect")).toBe(1);
+    controller.dispose();
+  });
+
+  it("reconnects local-first when the fallback itself disconnects", async () => {
+    const harness = new ClientHarness();
+    harness.fail(PRIMARY, "connect", new Error("ECONNREFUSED"));
+    const { controller } = createController(harness);
+    await connect(controller);
+    (controller.client as unknown as FakeClient).emit("disconnect");
+    await vi.advanceTimersByTimeAsync(6_000);
+    expect((controller.client as unknown as FakeClient).hostname).toBe(LOCAL);
+    expect(harness.count(LOCAL, "connect")).toBe(2);
+    controller.dispose();
+  });
+
+  it("collapses simultaneous read failures into one transition and retries both reads", async () => {
+    const { controller, harness } = createController();
+    await connect(controller);
+    harness.fail(
+      PRIMARY,
+      "get /devices/a",
+      new Error("Socket closed while request was pending"),
+      new Error("Socket closed while request was pending"),
+    );
+    const reads = Promise.all([
+      controller.transport.get("/devices/a"),
+      controller.transport.get("/devices/a"),
+    ]);
+    await vi.advanceTimersByTimeAsync(1_000);
+    await reads;
+    expect(harness.count(LOCAL, "connect")).toBe(1);
+    expect(harness.count(LOCAL, "get /devices/a")).toBe(2);
+    controller.dispose();
+  });
+
+  it("does not replay an ambiguous write after a timeout", async () => {
+    const { controller, harness } = createController();
+    await connect(controller);
+    harness.fail(PRIMARY, "put /devices/a", new Error("Request timed out after 5000ms"));
+    const writing = controller.transport.put("/devices/a", { level: 100 });
+    const outcome = writing.then(
+      () => undefined,
+      (err: unknown) => err,
+    );
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(await outcome).toEqual(
+      expect.objectContaining({ message: "Request timed out after 5000ms" }),
+    );
+    expect((controller.client as unknown as FakeClient).hostname).toBe(LOCAL);
+    expect(harness.count(LOCAL, "put /devices/a")).toBe(0);
+    controller.dispose();
+  });
+
+  it("replays a write that was definitely rejected before socket.send", async () => {
+    const { controller, harness } = createController();
+    await connect(controller);
+    harness.fail(
+      PRIMARY,
+      "put /devices/a",
+      new Error("Socket instance is closing/closed, please reconnect"),
+    );
+    const writing = controller.transport.put("/devices/a", { level: 100 });
+    await vi.advanceTimersByTimeAsync(1_000);
+    await writing;
+    expect(harness.count(LOCAL, "put /devices/a")).toBe(1);
+    controller.dispose();
+  });
+
+  it("does not switch hosts for an application-level failure", async () => {
+    const { controller, harness } = createController();
+    await connect(controller);
+    harness.fail(PRIMARY, "get /devices/a", new Error("Unexpected response shape"));
+    await expect(controller.transport.get("/devices/a")).rejects.toThrow(
+      "Unexpected response shape",
+    );
+    expect(harness.count(LOCAL, "connect")).toBe(0);
+    controller.dispose();
+  });
+
+  it("probes and restores the primary without interrupting the local client", async () => {
+    const harness = new ClientHarness();
+    harness.fail(PRIMARY, "connect", new Error("ECONNREFUSED"));
+    const { controller } = createController(harness);
+    await connect(controller);
+    const local = controller.client;
+    await vi.advanceTimersByTimeAsync(31_000);
+    expect((controller.client as unknown as FakeClient).hostname).toBe(PRIMARY);
+    expect(harness.count(PRIMARY, "connect")).toBe(2);
+    expect(
+      harness.calls.findIndex((call) => call.hostname === LOCAL && call.operation === "close"),
+    ).toBeGreaterThan(
+      harness.calls.findIndex(
+        (call) => call.hostname === PRIMARY && call.operation === "get /ping",
+      ),
+    );
+    expect(local).not.toBe(controller.client);
+    controller.dispose();
+  });
+
+  it("keeps serving locally after a failed primary probe and schedules another", async () => {
+    const harness = new ClientHarness();
+    harness.fail(
+      PRIMARY,
+      "connect",
+      new Error("startup unavailable"),
+      new Error("probe unavailable"),
+    );
+    const { controller } = createController(harness);
+    await connect(controller);
+    await vi.advanceTimersByTimeAsync(31_000);
+    expect((controller.client as unknown as FakeClient).hostname).toBe(LOCAL);
+    await vi.advanceTimersByTimeAsync(31_000);
+    expect((controller.client as unknown as FakeClient).hostname).toBe(PRIMARY);
+    expect(harness.count(PRIMARY, "connect")).toBe(3);
+    controller.dispose();
+  });
+
+  it("keeps the resolved gateway password for both endpoints", async () => {
+    const harness = new ClientHarness();
+    harness.fail(PRIMARY, "connect", new Error("ECONNREFUSED"));
+    const accountConfig = {
+      ...rawConfig,
+      email: "owner@example.test",
+    } as unknown as PlatformConfig;
+    const resolver = vi.fn<() => Promise<string>>(async () => "gateway-secret");
+    const { controller } = createController(harness, accountConfig, {
+      gatewayPasswordResolver: resolver,
+    });
+    await connect(controller);
+    expect(resolver).toHaveBeenCalledOnce();
+    const connectedClients = harness.calls.filter((call) => call.operation === "connect");
+    for (const connected of connectedClients) {
+      const creations = harness.calls.filter(
+        (call) => call.operation === "create" && call.hostname === connected.hostname,
+      );
+      expect(creations.some((creation) => creation.password === "gateway-secret")).toBe(true);
+    }
+    controller.dispose();
+  });
+
+  it("cancels reconnect and primary-probe timers on dispose", async () => {
+    const harness = new ClientHarness();
+    harness.fail(PRIMARY, "connect", new Error("ECONNREFUSED"));
+    const { controller } = createController(harness);
+    await connect(controller);
+    const connectCount = harness.calls.filter((call) => call.operation === "connect").length;
+    controller.dispose();
+    await vi.advanceTimersByTimeAsync(10 * 60_000);
+    expect(harness.calls.filter((call) => call.operation === "connect")).toHaveLength(connectCount);
+  });
+
+  it("closes a connection candidate when disposed during a transition", async () => {
+    const harness = new ClientHarness();
+    const release = harness.deferConnect(PRIMARY);
+    const { controller } = createController(harness);
+    const connecting = controller.connect();
+    const outcome = connecting.then(
+      () => undefined,
+      (err: unknown) => err,
+    );
+    await vi.advanceTimersByTimeAsync(0);
+    const candidate = harness.clients.at(-1);
+    controller.dispose();
+    expect(harness.calls).toContainEqual({ hostname: PRIMARY, operation: "close" });
+    release();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(await outcome).toEqual(
+      expect.objectContaining({ message: "Tydom controller was disposed while connecting" }),
+    );
+    expect(candidate).toBe(controller.client);
+    expect(controller.isConnected).toBe(false);
+  });
+});

--- a/test/schema.spec.ts
+++ b/test/schema.spec.ts
@@ -4,7 +4,9 @@ import { describe, expect, it } from "vitest";
 import { PLATFORM_NAME } from "../src/config/env.js";
 import {
   DEFAULT_REFRESH_INTERVAL_MS,
+  DEFAULT_PRIMARY_RETRY_INTERVAL_MS,
   DEFAULT_STALE_AFTER_MS,
+  MIN_PRIMARY_RETRY_INTERVAL_MS,
   MIN_REFRESH_INTERVAL_MS,
   parseConfig,
 } from "../src/config.js";
@@ -44,9 +46,11 @@ describe("config.schema.json", () => {
       "hostname",
       "includedCategories",
       "includedDevices",
+      "localHostname",
       "locale",
       "password",
       "pin",
+      "primaryRetryInterval",
       "refreshInterval",
       "settings",
       "staleAfter",
@@ -86,6 +90,8 @@ describe("config.schema.json", () => {
     const props = schema.schema.properties;
     expect(props["refreshInterval"]?.default).toBe(DEFAULT_REFRESH_INTERVAL_MS / 1000);
     expect(props["refreshInterval"]?.minimum).toBe(MIN_REFRESH_INTERVAL_MS / 1000);
+    expect(props["primaryRetryInterval"]?.default).toBe(DEFAULT_PRIMARY_RETRY_INTERVAL_MS / 1000);
+    expect(props["primaryRetryInterval"]?.minimum).toBe(MIN_PRIMARY_RETRY_INTERVAL_MS / 1000);
     expect(props["staleAfter"]?.default).toBe(DEFAULT_STALE_AFTER_MS / 1000);
 
     const parsed = parseConfig(


### PR DESCRIPTION
## Summary

- add opt-in fallback from the primary Tydom endpoint to a LAN endpoint at startup and after a runtime disconnect
- preserve tydom-client's existing automatic reconnection path when no local fallback is configured
- make the controller the single retry owner only when local fallback is enabled, preventing retired clients from opening competing sockets
- serialize host transitions, keep resyncs coalesced, probe the primary while local remains active, and switch back atomically after recovery
- retry safe reads after a host switch while avoiding ambiguous write replay after a timeout
- reuse account-derived gateway credentials for both endpoints and stop reconnect, probe, refresh and candidate activity during shutdown
- expose localHostname and primaryRetryInterval through the parsed config, Homebridge schema and documentation
- add an isolated Homebridge protocol for direct LAN, startup fallback, runtime fallback, primary recovery and legacy TLS testing

## Rework against current main

This replaces the original v0.29-based implementation with a fresh implementation on v0.32.0. It keeps the reconnection tracking and one-at-a-time resync introduced in v0.31.2, and uses the current TydomTransport seam instead of presenting a partial client facade.

## Validation

- pnpm run test — lint, typecheck, 348 tests across 23 files, and format check
- pnpm run build
- git diff --check
